### PR TITLE
Fix: 텍스트 컴포넌트 as prop 리팩토링 및 문서화

### DIFF
--- a/packages/ui/src/components/text/Text.stories.tsx
+++ b/packages/ui/src/components/text/Text.stories.tsx
@@ -14,7 +14,28 @@ const meta: Meta<typeof Text> = {
     },
     as: {
       control: 'select',
-      options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'span', 'div'],
+      options: [
+        'h1',
+        'h2',
+        'h3',
+        'h4',
+        'h5',
+        'h6',
+        'p',
+        'span',
+        'div',
+        'label',
+        'li',
+        'blockquote',
+        'caption',
+        'legend',
+        'figcaption',
+        'dt',
+        'dd',
+        'small',
+        'strong',
+        'em',
+      ],
     },
     color: { control: 'color' },
     width: { control: 'text' },
@@ -37,13 +58,6 @@ export const Default: Story = {
   args: {
     children: 'Default text example',
     variant: 'B1',
-  },
-  parameters: {
-    docs: {
-      source: {
-        code: '<Text variant="B1">Default text example</Text>',
-      },
-    },
   },
 };
 
@@ -68,52 +82,36 @@ export const AllVariants: Story = {
       <Text variant='O'>O - 오버라인</Text>
     </div>
   ),
-  parameters: {
-    docs: {
-      source: {
-        code: `<Text variant="H1" as="h1">H1 - 헤딩 1</Text>
-<Text variant="H2" as="h2">H2 - 헤딩 2</Text>
-<Text variant="H3" as="h3">H3 - 헤딩 3</Text>
-<Text variant="ST" as="h4">ST - 서브타이틀</Text>
-<Text variant="B1">B1 - 본문 1</Text>
-<Text variant="B2">B2 - 본문 2</Text>
-<Text variant="C">C - 캡션</Text>
-<Text variant="O">O - 오버라인</Text>`,
-      },
-    },
-  },
 };
 
-export const Playground: Story = {
-  args: {
-    children: 'Edit me in the controls panel!',
-    variant: 'B1',
-    color: '#000',
-    width: 'auto',
-    textAlign: 'left',
-    ellipsis: false,
-  },
-  parameters: {
-    docs: {
-      source: {
-        code: `<Text 
-  variant="B1" 
-  color="#000" 
-  width="auto" 
-  textAlign="left" 
-  ellipsis={false}
->
-  Edit me in the controls panel!
-</Text>`,
-      },
-    },
-  },
+export const WithCustomElements: Story = {
+  render: () => (
+    <div className='space-y-4'>
+      <Text as='label' variant='O'>
+        Label element
+      </Text>
+      <Text as='span' variant='B2'>
+        Span element
+      </Text>
+      <Text as='div' variant='B1'>
+        Div element
+      </Text>
+      <Text as='li' variant='B2'>
+        List item element
+      </Text>
+      <Text as='caption' variant='C'>
+        Table caption
+      </Text>
+      <Text as='blockquote' variant='B1'>
+        Blockquote element
+      </Text>
+    </div>
+  ),
 };
 
 export const Styling: Story = {
   render: () => (
     <div className='space-y-6'>
-      {/* Colors */}
       <div>
         <Text variant='ST' className='mb-2'>
           Colors
@@ -125,7 +123,6 @@ export const Styling: Story = {
         </div>
       </div>
 
-      {/* Text Alignment */}
       <div style={{ width: '300px' }}>
         <Text variant='ST' className='mb-2'>
           Text Alignment
@@ -137,7 +134,6 @@ export const Styling: Story = {
         </div>
       </div>
 
-      {/* Width Control */}
       <div>
         <Text variant='ST' className='mb-2'>
           Width Control
@@ -148,26 +144,6 @@ export const Styling: Story = {
       </div>
     </div>
   ),
-  parameters: {
-    docs: {
-      source: {
-        code: `{/* Colors */}
-<Text color="#3b82f6">Blue text</Text>
-<Text color="#dc2626">Red text</Text>
-<Text color="#059669">Green text</Text>
-
-{/* Text Alignment */}
-<Text textAlign="left">Left aligned</Text>
-<Text textAlign="center">Center aligned</Text>
-<Text textAlign="right">Right aligned</Text>
-
-{/* Width Control */}
-<Text width={200}>
-  이 텍스트는 200px 너비로 제한됩니다.
-</Text>`,
-      },
-    },
-  },
 };
 
 export const Ellipsis: Story = {
@@ -184,72 +160,15 @@ export const Ellipsis: Story = {
       </div>
     </div>
   ),
-  parameters: {
-    docs: {
-      source: {
-        code: `{/* With ellipsis */}
-<Text ellipsis>매우 긴 텍스트로 말줄임표가 적용됩니다.</Text>
-
-{/* Without ellipsis */}
-<Text ellipsis={false}>자연스럽게 줄바꿈되는 긴 텍스트입니다.</Text>`,
-      },
-    },
-  },
 };
 
-export const WhiteSpace: Story = {
-  render: () => (
-    <div className='space-y-4' style={{ width: '250px' }}>
-      <Text variant='ST'>White Space Options</Text>
-
-      <div className='border p-2 rounded'>
-        <Text variant='C' whiteSpace='normal'>
-          Normal: 여러 공백과{'\n'}줄바꿈이 있는 텍스트
-        </Text>
-      </div>
-
-      <div className='border p-2 rounded'>
-        <Text variant='C' whiteSpace='nowrap'>
-          Nowrap: 아무리 길어도 줄바꿈되지 않는 텍스트
-        </Text>
-      </div>
-
-      <div className='border p-2 rounded'>
-        <Text variant='C' whiteSpace='pre'>
-          Pre: 여러 공백과{'\n'}줄바꿈이 보존되는 텍스트
-        </Text>
-      </div>
-    </div>
-  ),
-  parameters: {
-    docs: {
-      source: {
-        code: `<Text whiteSpace="normal">Normal: 자동 줄바꿈</Text>
-<Text whiteSpace="nowrap">Nowrap: 줄바꿈 안됨</Text>
-<Text whiteSpace="pre">Pre: 공백과 줄바꿈 보존</Text>`,
-      },
-    },
-  },
-};
-
-export const Accessibility: Story = {
+export const Playground: Story = {
   args: {
+    children: 'Edit me in the controls panel!',
     variant: 'B1',
-    children: 'Screen reader friendly text',
-    'aria-label': 'Alternative text for screen readers',
-    role: 'status',
-  },
-  parameters: {
-    docs: {
-      source: {
-        code: `<Text 
-  variant="B1" 
-  aria-label="Alternative text for screen readers" 
-  role="status"
->
-  Screen reader friendly text
-</Text>`,
-      },
-    },
+    color: '#000',
+    width: 'auto',
+    textAlign: 'left',
+    ellipsis: false,
   },
 };

--- a/packages/ui/src/components/text/Text.tsx
+++ b/packages/ui/src/components/text/Text.tsx
@@ -5,7 +5,7 @@ import { type TextVariant, textVariants } from './variants';
 
 interface TextProps extends React.HTMLAttributes<HTMLElement> {
   variant?: TextVariant;
-  as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'span' | 'div';
+  as?: React.ElementType;
   className?: string;
   children: React.ReactNode;
   color?: string;
@@ -13,11 +13,6 @@ interface TextProps extends React.HTMLAttributes<HTMLElement> {
   textAlign?: 'left' | 'center' | 'right' | 'justify';
   whiteSpace?: 'normal' | 'nowrap' | 'pre' | 'pre-wrap' | 'pre-line';
   ellipsis?: boolean;
-
-  'aria-label'?: string;
-  'aria-describedby'?: string;
-  'aria-labelledby'?: string;
-  role?: string;
 }
 
 export const Text = ({


### PR DESCRIPTION
## 🎫 관련 이슈

[//]: # 'close 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.'
[//]: # '예시: close #1'

close #49

<br>

## 📄 개요

[//]: # '작업 내용을 간단히 요약해서 적습니다.'
[//]: # '예시: 로그인 폼 컴포넌트를 구현했습니다.'

> 텍스트 컴포넌트에 as prop을 좀 더 강화함

<br>

## 🔨 작업 내용

[//]: # '작업 내용을 자세하게 적습니다.'
[//]: # '붙임표 "-" 을 사용해서 목록을 만듭니다.'
[//]: # '예시: - 로그인 폼 UI 컴포넌트 구현'

- as prop 타입 안정성
- 스토리 작성

<br>

## 🖼️ 스크린샷/화면 녹화

[//]: # 'UI 변경사항이 있다면 스크린샷이나 GIF를 첨부해주세요.'
[//]: # '모바일/데스크톱 화면 모두 확인이 필요한 경우 각각 첨부해주세요.'

<!-- 스크린샷 첨부 -->

<br>

## 🏁 확인 사항

[//]: # 'PR을 보내기 전 다음 사항을 확인해주세요.'
[//]: # '해당 사항을 모두 이행해야 머지할 수 있습니다.'
[//]: # '- [x] 를 사용해서 완료로 표시할 수 있습니다.'

- [x] 테스트를 완료했나요?
- [x] 코드 컨벤션을 준수했나요? (Biome 검사 통과)
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?
- [x] 접근성(a11y)을 고려했나요?

<br>

## 🙋🏻 덧붙일 말

[//]: # '다음 사항이 있다면 적어주세요.'
[//]: # 'PR에 대한 추가 설명'
[//]: # '중점적으로 리뷰받고 싶은 부분'
[//]: # '기타 등등'
