### PR TITLE
Refactor: TextField 컴포넌트 리팩토링 및 스토리 작성

### DIFF
--- a/apps/storybook/src/TextField.stories.tsx
+++ b/apps/storybook/src/TextField.stories.tsx
@@ -10,53 +10,32 @@ const meta: Meta<typeof TextField> = {
     docs: {
       description: {
         component: `
-텍스트 입력을 위한 기본 컴포넌트입니다. 레이블, 아이콘, 에러 상태 등을 지원합니다.
+사용자 입력을 위한 텍스트 필드 컴포넌트입니다. 다양한 상태와 스타일링을 지원하며, 디자인 시스템의 일관성을 유지합니다.
 
-## 주요 기능
-
-- **자동 ID 생성**: useId를 통한 레이블-입력 필드 연결
-- **아이콘 지원**: 왼쪽에 Material Symbol 아이콘 표시
-- **에러 상태**: 보더 색상과 에러 메시지 표시
-- **Filled 상태**: value나 defaultValue가 있을 때 primary 색상 적용
-- **접근성**: 레이블과 입력 필드의 적절한 연결
-- **TypeScript**: 완전한 타입 지원과 HTML input 속성 상속
+## ✨ 주요 특징
+- 🏷️ **스마트 라벨링**: 자동 ID 연결로 접근성 지원
+- 🎯 **상태별 피드백**: 입력값 유무와 에러 상태에 따른 색상 변화
+- 🎨 **아이콘 통합**: Material Symbols와 간격 최적화
+- 📐 **유연한 크기**: width prop으로 레이아웃 대응
+- ⌨️ **키보드 네비게이션**: 접근성과 사용성 보장
+- 🎭 **애니메이션**: 부드러운 상태 전환
         `,
       },
     },
   },
   tags: ['autodocs'],
   argTypes: {
-    label: {
+    label: { control: 'text', description: '텍스트 필드의 라벨' },
+    placeholder: { control: 'text', description: '플레이스홀더 텍스트' },
+    icon: { control: 'text', description: '표시할 아이콘 이름' },
+    error: { control: 'boolean', description: '에러 상태 여부' },
+    disabled: { control: 'boolean', description: '비활성화 여부' },
+    errorMessage: { control: 'text', description: '에러 메시지' },
+    value: { control: 'text', description: '제어된 컴포넌트의 값' },
+    defaultValue: { control: 'text', description: '비제어 컴포넌트의 기본값' },
+    width: {
       control: 'text',
-      description: 'The label for the text field.',
-    },
-    placeholder: {
-      control: 'text',
-      description: 'The placeholder text.',
-    },
-    icon: {
-      control: 'text',
-      description: 'The name of the icon to display.',
-    },
-    error: {
-      control: 'boolean',
-      description: 'Whether the text field is in an error state.',
-    },
-    disabled: {
-      control: 'boolean',
-      description: 'Whether the text field is disabled.',
-    },
-    errorMessage: {
-      control: 'text',
-      description: 'The error message to display.',
-    },
-    value: {
-      control: 'text',
-      description: 'The value of the text field (for controlled components).',
-    },
-    defaultValue: {
-      control: 'text',
-      description: 'The default value of the text field (for uncontrolled components).',
+      description: '텍스트 필드 너비 (예: "100%", "20rem", 숫자는 px)',
     },
   },
   args: {
@@ -86,24 +65,24 @@ export const Default: Story = {
 
 export const WithIcon: Story = {
   render: () => (
-    <div className='flex flex-col gap-4 w-[400px]'>
+    <div style={{ display: 'grid', gap: '16px', maxWidth: '400px' }}>
       <TextField icon='search' label='검색' placeholder='검색어를 입력하세요' />
       <TextField icon='mail' label='이메일' placeholder='example@email.com' type='email' />
-      <TextField icon='lock' label='비밀번호' placeholder='비밀번호를 입력하세요' type='password' />
-      <TextField icon='person' label='사용자명' placeholder='사용자명을 입력하세요' />
-      <TextField icon='phone' label='전화번호' placeholder='010-1234-5678' type='tel' />
+      <TextField icon='lock' label='비밀번호' placeholder='비밀번호 입력' type='password' />
     </div>
   ),
   parameters: {
     docs: {
       description: {
         story:
-          '다양한 Material Symbol 아이콘을 사용할 수 있습니다. 아이콘은 입력 필드 왼쪽에 12px 간격으로 표시됩니다.',
+          '아이콘이 있는 입력 필드는 시각적 구분과 명확한 입력 가이드를 제공합니다. 아이콘과 텍스트 간 간격은 8px로 최적화.',
       },
       source: {
-        code: `<TextField icon="search" label="검색" placeholder="검색어를 입력하세요" />
+        code: `
+<TextField icon="search" label="검색" placeholder="검색어를 입력하세요" />
 <TextField icon="mail" label="이메일" placeholder="example@email.com" type="email" />
-<TextField icon="lock" label="비밀번호" type="password" />`,
+<TextField icon="lock" label="비밀번호" placeholder="비밀번호 입력" type="password" />
+        `,
       },
     },
   },
@@ -111,7 +90,7 @@ export const WithIcon: Story = {
 
 export const ErrorState: Story = {
   render: () => (
-    <div className='flex flex-col gap-4 w-[400px]'>
+    <div style={{ display: 'grid', gap: '16px', maxWidth: '400px' }}>
       <TextField
         label='이메일'
         defaultValue='잘못된이메일'
@@ -119,28 +98,23 @@ export const ErrorState: Story = {
         errorMessage='올바른 이메일 형식이 아닙니다'
       />
       <TextField icon='warning' label='필수 입력' error errorMessage='필수 입력 항목입니다' />
-      <TextField
-        icon='lock'
-        label='비밀번호'
-        defaultValue='123'
-        error
-        errorMessage='비밀번호는 최소 8자 이상이어야 합니다'
-        type='password'
-      />
     </div>
   ),
   parameters: {
     docs: {
       description: {
-        story: '에러 상태일 때 보더가 빨간색으로 변경되고 하단에 에러 메시지가 표시됩니다.',
+        story:
+          '에러 상태에서는 빨간색 보더와 명확한 에러 메시지가 표시되어 사용자가 문제를 즉시 인식 가능.',
       },
       source: {
-        code: `<TextField
+        code: `
+<TextField
   label="이메일"
   defaultValue="잘못된이메일"
   error
   errorMessage="올바른 이메일 형식이 아닙니다"
-/>`,
+/>
+        `,
       },
     },
   },
@@ -148,21 +122,23 @@ export const ErrorState: Story = {
 
 export const FilledState: Story = {
   render: () => (
-    <div className='flex flex-col gap-4 w-[400px]'>
+    <div style={{ display: 'grid', gap: '16px', maxWidth: '400px' }}>
       <TextField label='빈 상태' placeholder='내용을 입력하세요' />
-      <TextField label='입력된 상태' defaultValue='입력된 내용' />
-      <TextField label='제어된 상태' value='제어된 값' onChange={() => {}} />
-      <TextField icon='person' label='사용자' defaultValue='홍길동' />
+      <TextField label='입력된 상태' defaultValue='홍길동' />
+      <TextField label='제어된 상태' value='실시간 값' onChange={() => {}} />
     </div>
   ),
   parameters: {
     docs: {
       description: {
-        story: 'value나 defaultValue가 있을 때 보더가 primary-500 색상으로 변경됩니다.',
+        story: '입력된 상태에서는 검정색 라벨과 파란색 보더(1px)가 적용되며, 포커스 시 2px로 강조.',
       },
       source: {
-        code: `<TextField label="입력된 상태" defaultValue="입력된 내용" />
-<TextField label="제어된 상태" value="제어된 값" onChange={handleChange} />`,
+        code: `
+<TextField label="빈 상태" placeholder="내용을 입력하세요" />
+<TextField label="입력된 상태" defaultValue="홍길동" />
+<TextField label="제어된 상태" value="실시간 값" onChange={handleChange} />
+        `,
       },
     },
   },
@@ -170,76 +146,18 @@ export const FilledState: Story = {
 
 export const Disabled: Story = {
   render: () => (
-    <div className='flex flex-col gap-4 w-[400px]'>
-      <TextField label='비활성화' placeholder='입력할 수 없습니다' disabled />
-      <TextField label='값이 있는 비활성화' defaultValue='수정할 수 없음' disabled />
-      <TextField icon='lock' label='잠긴 필드' defaultValue='읽기 전용' disabled />
+    <div style={{ display: 'grid', gap: '16px', maxWidth: '400px' }}>
+      <TextField label='비활성화' placeholder='입력 불가' disabled />
+      <TextField label='값 포함 비활성화' defaultValue='읽기 전용' disabled />
     </div>
   ),
   parameters: {
     docs: {
       source: {
-        code: `<TextField label="비활성화" placeholder="입력할 수 없습니다" disabled />
-<TextField label="값이 있는 비활성화" defaultValue="수정할 수 없음" disabled />`,
-      },
-    },
-  },
-};
-
-export const AllStates: Story = {
-  render: () => (
-    <div className='space-y-8'>
-      <div>
-        <h3 className='font-semibold text-lg mb-4'>기본 상태</h3>
-        <div className='space-y-4 w-[400px]'>
-          <TextField label='기본' placeholder='내용을 입력하세요' />
-          <TextField label='값이 있음' defaultValue='입력된 내용' />
-          <TextField icon='search' label='아이콘 포함' placeholder='검색어 입력' />
-        </div>
-      </div>
-
-      <div>
-        <h3 className='font-semibold text-lg mb-4'>에러 상태</h3>
-        <div className='space-y-4 w-[400px]'>
-          <TextField
-            label='에러'
-            placeholder='필수 입력'
-            error
-            errorMessage='필수 입력 항목입니다'
-          />
-          <TextField
-            label='잘못된 값'
-            defaultValue='invalid@'
-            error
-            errorMessage='올바른 이메일을 입력하세요'
-          />
-          <TextField
-            icon='warning'
-            label='경고'
-            defaultValue='잘못된 값'
-            error
-            errorMessage='형식이 올바르지 않습니다'
-          />
-        </div>
-      </div>
-
-      <div>
-        <h3 className='font-semibold text-lg mb-4'>비활성화 상태</h3>
-        <div className='space-y-4 w-[400px]'>
-          <TextField label='비활성화' placeholder='입력 불가' disabled />
-          <TextField label='값 포함 비활성화' defaultValue='읽기 전용' disabled />
-          <TextField icon='lock' label='잠금' defaultValue='변경 불가' disabled />
-        </div>
-      </div>
-    </div>
-  ),
-  parameters: {
-    docs: {
-      source: {
-        code: `// 모든 상태의 시각적 비교
-<TextField label="기본" placeholder="내용을 입력하세요" />
-<TextField label="에러" error errorMessage="필수 입력 항목입니다" />
-<TextField label="비활성화" disabled />`,
+        code: `
+<TextField label="비활성화" placeholder="입력 불가" disabled />
+<TextField label="값 포함 비활성화" defaultValue="읽기 전용" disabled />
+        `,
       },
     },
   },
@@ -247,32 +165,70 @@ export const AllStates: Story = {
 
 export const FormExample: Story = {
   render: () => (
-    <div className='max-w-md p-6 border rounded-lg'>
-      <h3 className='text-lg font-semibold mb-4'>회원가입 폼</h3>
-      <div className='space-y-4'>
+    <div
+      style={{
+        maxWidth: '600px',
+        padding: '24px',
+        borderRadius: '8px',
+        border: '1px solid #dbeafe',
+      }}
+    >
+      <h3 style={{ fontSize: '20px', fontWeight: 600, marginBottom: '16px' }}>회원가입</h3>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '16px' }}>
         <TextField icon='person' label='이름' placeholder='홍길동' />
         <TextField icon='mail' label='이메일' placeholder='example@email.com' type='email' />
-        <TextField icon='lock' label='비밀번호' placeholder='8자 이상 입력하세요' type='password' />
-        <TextField icon='phone' label='전화번호' placeholder='010-1234-5678' type='tel' />
-        <TextField label='주소' placeholder='서울시 강남구...' />
+        <TextField icon='lock' label='비밀번호' placeholder='8자 이상' type='password' />
         <TextField
-          label='자기소개'
-          placeholder='간단한 자기소개를 작성해주세요'
-          defaultValue='안녕하세요'
+          icon='verified_user'
+          label='비밀번호 확인'
+          placeholder='비밀번호 재입력'
+          type='password'
         />
       </div>
+      <TextField
+        label='주소'
+        placeholder='서울시 강남구...'
+        width='100%'
+        style={{ marginTop: '16px' }}
+      />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: '실제 폼 구성 예시로, 그룹핑과 아이콘을 활용해 직관적인 사용자 경험 제공.',
+      },
+      source: {
+        code: `
+<TextField icon="person" label="이름" placeholder="홍길동" />
+<TextField icon="mail" label="이메일" placeholder="example@email.com" type="email" />
+<TextField icon="lock" label="비밀번호" placeholder="8자 이상" type="password" />
+        `,
+      },
+    },
+  },
+};
+
+export const WidthVariations: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: '16px', maxWidth: '600px' }}>
+      <TextField label='Compact (250px)' placeholder='좁은 필드' width={250} />
+      <TextField label='Standard (400px)' placeholder='표준 필드' />
+      <TextField label='Full Width' placeholder='전체 너비' width='100%' />
     </div>
   ),
   parameters: {
     docs: {
       description: {
         story:
-          '실제 폼에서 사용되는 TextField의 예시입니다. 다양한 입력 타입과 아이콘을 조합하여 사용할 수 있습니다.',
+          'width prop으로 레이아웃에 맞는 크기 조정 가능. 숫자는 px, 문자열은 CSS 값으로 사용.',
       },
       source: {
-        code: `<TextField icon="person" label="이름" placeholder="홍길동" />
-<TextField icon="mail" label="이메일" type="email" />
-<TextField icon="lock" label="비밀번호" type="password" />`,
+        code: `
+<TextField width={250} label="Compact" placeholder="좁은 필드" />
+<TextField label="Standard" placeholder="표준 필드" />
+<TextField width="100%" label="Full Width" placeholder="전체 너비" />
+        `,
       },
     },
   },
@@ -286,19 +242,22 @@ export const Playground: Story = {
     error: false,
     errorMessage: '',
     disabled: false,
-    defaultValue: '',
+    width: '400px',
   },
   parameters: {
     docs: {
       source: {
-        code: `<TextField
+        code: `
+<TextField
   label="라벨"
   placeholder="내용을 입력하세요"
   icon=""
   error={false}
   errorMessage=""
   disabled={false}
-/>`,
+  width="400px"
+/>
+        `,
       },
     },
   },

--- a/apps/storybook/src/TextField.stories.tsx
+++ b/apps/storybook/src/TextField.stories.tsx
@@ -53,6 +53,7 @@ export const Default: Story = {
   args: {
     label: '이름',
     placeholder: '이름을 입력하세요',
+    width: '400px',
   },
   parameters: {
     docs: {
@@ -66,9 +67,21 @@ export const Default: Story = {
 export const WithIcon: Story = {
   render: () => (
     <div style={{ display: 'grid', gap: '16px', maxWidth: '400px' }}>
-      <TextField icon='search' label='검색' placeholder='검색어를 입력하세요' />
-      <TextField icon='mail' label='이메일' placeholder='example@email.com' type='email' />
-      <TextField icon='lock' label='비밀번호' placeholder='비밀번호 입력' type='password' />
+      <TextField icon='search' label='검색' placeholder='검색어를 입력하세요' width='400px' />
+      <TextField
+        icon='mail'
+        label='이메일'
+        placeholder='example@email.com'
+        type='email'
+        width='400px'
+      />
+      <TextField
+        icon='lock'
+        label='비밀번호'
+        placeholder='비밀번호 입력'
+        type='password'
+        width='400px'
+      />
     </div>
   ),
   parameters: {
@@ -96,8 +109,15 @@ export const ErrorState: Story = {
         defaultValue='잘못된이메일'
         error
         errorMessage='올바른 이메일 형식이 아닙니다'
+        width='400px'
       />
-      <TextField icon='warning' label='필수 입력' error errorMessage='필수 입력 항목입니다' />
+      <TextField
+        icon='warning'
+        label='필수 입력'
+        error
+        errorMessage='필수 입력 항목입니다'
+        width='400px'
+      />
     </div>
   ),
   parameters: {
@@ -123,9 +143,9 @@ export const ErrorState: Story = {
 export const FilledState: Story = {
   render: () => (
     <div style={{ display: 'grid', gap: '16px', maxWidth: '400px' }}>
-      <TextField label='빈 상태' placeholder='내용을 입력하세요' />
-      <TextField label='입력된 상태' defaultValue='홍길동' />
-      <TextField label='제어된 상태' value='실시간 값' onChange={() => {}} />
+      <TextField label='빈 상태' placeholder='내용을 입력하세요' width='400px' />
+      <TextField label='입력된 상태' defaultValue='홍길동' width='400px' />
+      <TextField label='제어된 상태' value='실시간 값' onChange={() => {}} width='400px' />
     </div>
   ),
   parameters: {
@@ -147,8 +167,8 @@ export const FilledState: Story = {
 export const Disabled: Story = {
   render: () => (
     <div style={{ display: 'grid', gap: '16px', maxWidth: '400px' }}>
-      <TextField label='비활성화' placeholder='입력 불가' disabled />
-      <TextField label='값 포함 비활성화' defaultValue='읽기 전용' disabled />
+      <TextField label='비활성화' placeholder='입력 불가' disabled width='400px' />
+      <TextField label='값 포함 비활성화' defaultValue='읽기 전용' disabled width='400px' />
     </div>
   ),
   parameters: {
@@ -175,14 +195,27 @@ export const FormExample: Story = {
     >
       <h3 style={{ fontSize: '20px', fontWeight: 600, marginBottom: '16px' }}>회원가입</h3>
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '16px' }}>
-        <TextField icon='person' label='이름' placeholder='홍길동' />
-        <TextField icon='mail' label='이메일' placeholder='example@email.com' type='email' />
-        <TextField icon='lock' label='비밀번호' placeholder='8자 이상' type='password' />
+        <TextField icon='person' label='이름' placeholder='홍길동' width='400px' />
+        <TextField
+          icon='mail'
+          label='이메일'
+          placeholder='example@email.com'
+          type='email'
+          width='400px'
+        />
+        <TextField
+          icon='lock'
+          label='비밀번호'
+          placeholder='8자 이상'
+          type='password'
+          width='400px'
+        />
         <TextField
           icon='verified_user'
           label='비밀번호 확인'
           placeholder='비밀번호 재입력'
           type='password'
+          width='400px'
         />
       </div>
       <TextField
@@ -213,7 +246,7 @@ export const WidthVariations: Story = {
   render: () => (
     <div style={{ display: 'grid', gap: '16px', maxWidth: '600px' }}>
       <TextField label='Compact (250px)' placeholder='좁은 필드' width={250} />
-      <TextField label='Standard (400px)' placeholder='표준 필드' />
+      <TextField label='Standard (400px)' placeholder='표준 필드' width='400px' />
       <TextField label='Full Width' placeholder='전체 너비' width='100%' />
     </div>
   ),

--- a/packages/ui/src/TextField/TextField.tsx
+++ b/packages/ui/src/TextField/TextField.tsx
@@ -56,7 +56,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
 
       return (
         <StyledIconWrapper aria-hidden>
-          <Icon name={icon} variant='SM' color={tokens.colors.neutral[400]} />
+          <Icon name={icon} variant='SM' color={isFilled ? 'black' : tokens.colors.neutral[400]} />
         </StyledIconWrapper>
       );
     };
@@ -79,7 +79,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
           <Text
             as='label'
             variant='O'
-            color={isFilled || error ? 'black' : tokens.colors.neutral[400]}
+            color={isFilled ? 'black' : tokens.colors.neutral[400]}
             htmlFor={resolvedId}
             className={labelClassName}
           >
@@ -146,7 +146,8 @@ const StyledInput = styled('input', { shouldForwardProp })<StyledInputProps>`
   width: 100%;
   align-items: center;
   border-radius: ${tokens.rounding.object};
-  border: ${tokens.stroke.weight} solid;
+  border: ${tokens.stroke.weight} solid transparent;
+  box-shadow: inset 0 0 0 ${tokens.stroke.weight};
   background-color: white;
   padding: 10px 12px;
   font-size: ${tokens.fontSize[14]};
@@ -154,6 +155,7 @@ const StyledInput = styled('input', { shouldForwardProp })<StyledInputProps>`
   line-height: ${tokens.lineHeight[22]};
   font-family: ${tokens.fontFamily.suit.join(', ')};
   color: black;
+  box-sizing: border-box;
   transition: all 0.2s ease-in-out;
 
   &::placeholder {
@@ -162,7 +164,7 @@ const StyledInput = styled('input', { shouldForwardProp })<StyledInputProps>`
 
   &:focus {
     outline: none;
-    border-width: 2px;
+    box-shadow: inset 0 0 0 2px;
   }
 
   &:disabled {
@@ -179,10 +181,10 @@ const StyledInput = styled('input', { shouldForwardProp })<StyledInputProps>`
   ${({ hasError }) =>
     hasError &&
     css`
-      border-color: ${tokens.colors.warning[200]};
+      box-shadow: inset 0 0 0 ${tokens.stroke.weight} ${tokens.colors.warning[200]};
       
       &:focus {
-        border-color: ${tokens.colors.warning[200]};
+        box-shadow: inset 0 0 0 2px ${tokens.colors.warning[200]};
       }
     `}
   
@@ -190,10 +192,10 @@ const StyledInput = styled('input', { shouldForwardProp })<StyledInputProps>`
     !hasError &&
     filled &&
     css`
-      border-color: ${tokens.colors.primary[500]};
+      box-shadow: inset 0 0 0 ${tokens.stroke.weight} ${tokens.colors.primary[500]};
       
       &:focus {
-        border-color: ${tokens.colors.primary[500]};
+        box-shadow: inset 0 0 0 2px ${tokens.colors.primary[500]};
       }
     `}
   
@@ -201,10 +203,10 @@ const StyledInput = styled('input', { shouldForwardProp })<StyledInputProps>`
     !hasError &&
     !filled &&
     css`
-      border-color: ${tokens.colors.neutral[300]};
+      box-shadow: inset 0 0 0 ${tokens.stroke.weight} ${tokens.colors.neutral[300]};
       
       &:focus {
-        border-color: ${tokens.colors.primary[500]};
+        box-shadow: inset 0 0 0 2px ${tokens.colors.primary[500]};
       }
     `}
 `;

--- a/packages/ui/src/TextField/TextField.tsx
+++ b/packages/ui/src/TextField/TextField.tsx
@@ -6,114 +6,7 @@ import { tokens } from '@horizon/tokens';
 import type React from 'react';
 import { forwardRef, useCallback, useId, useState } from 'react';
 
-const StyledContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-`;
-
-interface StyledInputWrapperProps {
-  width?: string | number;
-}
-
-const StyledInputWrapper = styled.div<StyledInputWrapperProps>`
-  position: relative;
-  width: ${({ width }) => (typeof width === 'number' ? `${width}px` : width || '400px')};
-`;
-
-const StyledIconWrapper = styled.div`
-  position: absolute;
-  left: 12px;
-  top: 50%;
-  transform: translateY(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  pointer-events: none;
-`;
-
-const shouldForwardProp = (prop: string) => ['hasError', 'hasIcon', 'filled'].indexOf(prop) === -1;
-
-interface StyledInputProps {
-  hasError: boolean;
-  hasIcon: boolean;
-  filled: boolean;
-}
-
-const StyledInput = styled('input', { shouldForwardProp })<StyledInputProps>`
-  display: flex;
-  height: 40px;
-  width: 100%;
-  align-items: center;
-  border-radius: ${tokens.rounding.object};
-  border: ${tokens.stroke.weight} solid;
-  background-color: white;
-  padding: 10px 12px;
-  font-size: ${tokens.fontSize[14]};
-  font-weight: ${tokens.fontWeight.light};
-  line-height: ${tokens.lineHeight[22]};
-  font-family: ${tokens.fontFamily.suit.join(', ')};
-  color: black;
-  transition: all 0.2s ease-in-out;
-
-  &::placeholder {
-    color: ${tokens.colors.neutral[400]};
-  }
-
-  &:focus {
-    outline: none;
-    border-width: 2px;
-  }
-
-  &:disabled {
-    cursor: not-allowed;
-    opacity: 0.5;
-  }
-
-  ${({ hasIcon }) =>
-    hasIcon &&
-    css`
-      padding-left: 36px;
-    `}
-
-  ${({ hasError }) =>
-    hasError &&
-    css`
-      border-color: ${tokens.colors.warning[200]};
-      
-      &:focus {
-        border-color: ${tokens.colors.warning[200]};
-      }
-    `}
-  
-  ${({ filled, hasError }) =>
-    !hasError &&
-    filled &&
-    css`
-      border-color: ${tokens.colors.primary[500]};
-      
-      &:focus {
-        border-color: ${tokens.colors.primary[500]};
-      }
-    `}
-  
-  ${({ filled, hasError }) =>
-    !hasError &&
-    !filled &&
-    css`
-      border-color: ${tokens.colors.neutral[300]};
-      
-      &:focus {
-        border-color: ${tokens.colors.primary[500]};
-      }
-    `}
-`;
-
-const StyledErrorMessage = styled.div`
-  text-align: center;
-`;
-
-export interface TextFieldProps
+interface TextFieldProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size' | 'width'> {
   label?: string;
   icon?: string;
@@ -123,6 +16,8 @@ export interface TextFieldProps
   labelClassName?: string;
   width?: string | number;
 }
+
+const shouldForwardProp = (prop: string) => ['hasError', 'hasIcon', 'filled'].indexOf(prop) === -1;
 
 export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
   (
@@ -209,3 +104,108 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
 );
 
 TextField.displayName = 'TextField';
+
+interface StyledInputWrapperProps {
+  width?: string | number;
+}
+
+interface StyledInputProps {
+  hasError: boolean;
+  hasIcon: boolean;
+  filled: boolean;
+}
+
+const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+const StyledInputWrapper = styled.div<StyledInputWrapperProps>`
+  position: relative;
+  width: ${({ width }) => (typeof width === 'number' ? `${width}px` : width || '400px')};
+`;
+
+const StyledIconWrapper = styled.div`
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+`;
+
+const StyledInput = styled('input', { shouldForwardProp })<StyledInputProps>`
+  display: flex;
+  height: 40px;
+  width: 100%;
+  align-items: center;
+  border-radius: ${tokens.rounding.object};
+  border: ${tokens.stroke.weight} solid;
+  background-color: white;
+  padding: 10px 12px;
+  font-size: ${tokens.fontSize[14]};
+  font-weight: ${tokens.fontWeight.light};
+  line-height: ${tokens.lineHeight[22]};
+  font-family: ${tokens.fontFamily.suit.join(', ')};
+  color: black;
+  transition: all 0.2s ease-in-out;
+
+  &::placeholder {
+    color: ${tokens.colors.neutral[400]};
+  }
+
+  &:focus {
+    outline: none;
+    border-width: 2px;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  ${({ hasIcon }) =>
+    hasIcon &&
+    css`
+      padding-left: 36px;
+    `}
+
+  ${({ hasError }) =>
+    hasError &&
+    css`
+      border-color: ${tokens.colors.warning[200]};
+      
+      &:focus {
+        border-color: ${tokens.colors.warning[200]};
+      }
+    `}
+  
+  ${({ filled, hasError }) =>
+    !hasError &&
+    filled &&
+    css`
+      border-color: ${tokens.colors.primary[500]};
+      
+      &:focus {
+        border-color: ${tokens.colors.primary[500]};
+      }
+    `}
+  
+  ${({ filled, hasError }) =>
+    !hasError &&
+    !filled &&
+    css`
+      border-color: ${tokens.colors.neutral[300]};
+      
+      &:focus {
+        border-color: ${tokens.colors.primary[500]};
+      }
+    `}
+`;
+
+const StyledErrorMessage = styled.div`
+  text-align: center;
+`;

--- a/packages/ui/src/TextField/TextField.tsx
+++ b/packages/ui/src/TextField/TextField.tsx
@@ -9,6 +9,8 @@ import { forwardRef, useCallback, useId, useState } from 'react';
 interface TextFieldProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size' | 'width'> {
   id?: string;
+  value?: string | number;
+  defaultValue?: string | number;
   label?: string;
   icon?: string;
   error?: boolean;
@@ -24,6 +26,9 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
   (
     {
       id,
+      value,
+      defaultValue,
+      onChange,
       label,
       icon,
       error = false,
@@ -37,20 +42,20 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
   ) => {
     const resolvedId = id ?? useId();
     const errorId = `${resolvedId}-error`;
-    const [internalValue, setInternalValue] = useState(restProps.defaultValue ?? '');
+    const [internalValue, setInternalValue] = useState(String(defaultValue ?? ''));
 
     const hasIcon = !!icon;
-    const currentValue = restProps.value !== undefined ? restProps.value : internalValue;
+    const currentValue = value !== undefined ? value : internalValue;
     const isFilled = !!String(currentValue).trim();
 
     const handleChange = useCallback(
       (e: React.ChangeEvent<HTMLInputElement>) => {
-        if (restProps.value === undefined) {
+        if (value === undefined) {
           setInternalValue(e.target.value);
         }
-        restProps.onChange?.(e);
+        onChange?.(e);
       },
-      [restProps.value, restProps.onChange]
+      [value, onChange]
     );
 
     const renderIcon = () => {
@@ -100,6 +105,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
             onChange={handleChange}
             aria-invalid={error || undefined}
             aria-describedby={error && errorMessage ? errorId : undefined}
+            value={currentValue}
           />
         </StyledInputWrapper>
         {renderErrorMessage()}

--- a/packages/ui/src/TextField/TextField.tsx
+++ b/packages/ui/src/TextField/TextField.tsx
@@ -126,7 +126,7 @@ const StyledContainer = styled.div`
 
 const StyledInputWrapper = styled.div<StyledInputWrapperProps>`
   position: relative;
-  width: ${({ width }) => (typeof width === 'number' ? `${width}px` : width || '400px')};
+  width: ${({ width }) => (typeof width === 'number' ? `${width}px` : (width ?? '100%'))};
 `;
 
 const StyledIconWrapper = styled.div`

--- a/packages/ui/src/TextField/TextField.tsx
+++ b/packages/ui/src/TextField/TextField.tsx
@@ -55,7 +55,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
       if (!hasIcon || !icon) return null;
 
       return (
-        <StyledIconWrapper>
+        <StyledIconWrapper aria-hidden>
           <Icon name={icon} variant='SM' color={tokens.colors.neutral[400]} />
         </StyledIconWrapper>
       );
@@ -129,7 +129,7 @@ const StyledInputWrapper = styled.div<StyledInputWrapperProps>`
   width: ${({ width }) => (typeof width === 'number' ? `${width}px` : (width ?? '100%'))};
 `;
 
-const StyledIconWrapper = styled.label`
+const StyledIconWrapper = styled.div`
   position: absolute;
   left: 12px;
   top: 50%;

--- a/packages/ui/src/TextField/TextField.tsx
+++ b/packages/ui/src/TextField/TextField.tsx
@@ -4,7 +4,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { tokens } from '@horizon/tokens';
 import type React from 'react';
-import { forwardRef, useCallback, useId, useMemo, useState } from 'react';
+import { forwardRef, useCallback, useId, useState } from 'react';
 
 interface TextFieldStyleProps {
   hasError: boolean;
@@ -15,17 +15,18 @@ interface TextFieldStyleProps {
 const StyledContainer = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: ${tokens.grid.gutterWidth};
 `;
 
 const StyledInputWrapper = styled.div`
   position: relative;
-  width: 400px;
+  width: 100%;
+  max-width: 400px;
 `;
 
 const StyledIconWrapper = styled.div`
   position: absolute;
-  left: 12px;
+  left: ${tokens.grid.gutterWidth};
   top: 50%;
   transform: translateY(-50%);
   display: flex;
@@ -39,15 +40,14 @@ const StyledInput = styled.input<TextFieldStyleProps>`
   height: 40px;
   width: 100%;
   align-items: center;
-  gap: 8px;
-  border-radius: 8px;
-  border: 1px solid;
+  border-radius: ${tokens.rounding.object};
+  border: ${tokens.stroke.weight} solid;
   background-color: white;
-  padding: 10px 12px;
-  font-size: 14px;
+  padding: 10px ${tokens.grid.gutterWidth};
+  font-size: ${tokens.fontSize[14]};
   font-weight: ${tokens.fontWeight.light};
-  line-height: 22px;
-  font-family: 'SUIT Variable', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  line-height: ${tokens.lineHeight[22]};
+  font-family: ${tokens.fontFamily.suit.join(', ')};
   color: black;
   transition: all 0.2s ease-in-out;
 
@@ -65,47 +65,47 @@ const StyledInput = styled.input<TextFieldStyleProps>`
     opacity: 0.5;
   }
 
-  /* Icon padding */
   ${({ hasIcon }) =>
     hasIcon &&
     css`
-    padding-left: 44px;
+      padding-left: 44px;
+    `}
+
+  ${({ hasError }) =>
+    hasError &&
+    css`
+    border-color: ${tokens.colors.warning[200]};
+    
+    &:focus {
+      border-color: ${tokens.colors.warning[200]};
+    }
   `}
-
-  /* Border colors based on state */
-  ${({ hasError, filled }) => {
-    if (hasError) {
-      return css`
-        border-color: ${tokens.colors.warning[200]};
-        
-        &:focus {
-          border-color: ${tokens.colors.warning[200]};
-        }
-      `;
+  
+  ${({ filled, hasError }) =>
+    !hasError &&
+    filled &&
+    css`
+    border-color: ${tokens.colors.primary[500]};
+    
+    &:focus {
+      border-color: ${tokens.colors.primary[500]};
     }
-
-    if (filled) {
-      return css`
-        border-color: ${tokens.colors.primary[500]};
-        
-        &:focus {
-          border-color: ${tokens.colors.primary[500]};
-        }
-      `;
+  `}
+  
+  ${({ filled, hasError }) =>
+    !hasError &&
+    !filled &&
+    css`
+    border-color: ${tokens.colors.neutral[300]};
+    
+    &:focus {
+      border-color: ${tokens.colors.primary[500]};
     }
-
-    return css`
-      border-color: ${tokens.colors.neutral[300]};
-      
-      &:focus {
-        border-color: ${tokens.colors.primary[500]};
-      }
-    `;
-  }}
+  `}
 `;
 
 const StyledErrorMessage = styled.div`
-  margin-top: 3px;
+  margin-top: 4px;
 `;
 
 interface TextFieldProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
@@ -123,11 +123,11 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
     ref
   ) => {
     const inputId = useId();
-    const [internalValue, setInternalValue] = useState(props.defaultValue || '');
+    const [internalValue, setInternalValue] = useState(props.defaultValue ?? '');
 
-    const hasIcon = useMemo(() => !!icon, [icon]);
+    const hasIcon = !!icon;
     const currentValue = props.value !== undefined ? props.value : internalValue;
-    const filled = useMemo(() => !!currentValue, [currentValue]);
+    const filled = !!String(currentValue).trim();
 
     const handleChange = useCallback(
       (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -170,7 +170,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         </StyledInputWrapper>
         {error && errorMessage && (
           <StyledErrorMessage>
-            <Text variant='C' color='warning.200' textAlign='center'>
+            <Text variant='C' color='warning.200'>
               {errorMessage}
             </Text>
           </StyledErrorMessage>

--- a/packages/ui/src/TextField/TextField.tsx
+++ b/packages/ui/src/TextField/TextField.tsx
@@ -33,7 +33,8 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
     },
     ref
   ) => {
-    const inputId = useId();
+    const resolvedId = (restProps.id as string | undefined) ?? useId();
+    const errorId = `${resolvedId}-error`;
     const [internalValue, setInternalValue] = useState(restProps.defaultValue ?? '');
 
     const hasIcon = !!icon;
@@ -64,7 +65,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
       if (!error || !errorMessage) return null;
 
       return (
-        <StyledErrorMessage>
+        <StyledErrorMessage id={errorId} role='alert' aria-live='polite'>
           <Text variant='C' color={tokens.colors.warning[200]} textAlign='center'>
             {errorMessage}
           </Text>
@@ -79,7 +80,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
             as='label'
             variant='O'
             color={isFilled || error ? 'black' : tokens.colors.neutral[400]}
-            htmlFor={inputId}
+            htmlFor={resolvedId}
             className={labelClassName}
           >
             {label}
@@ -88,12 +89,14 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         <StyledInputWrapper width={width}>
           {renderIcon()}
           <StyledInput
-            id={inputId}
+            id={resolvedId}
             ref={ref}
             hasError={error}
             hasIcon={hasIcon}
             filled={isFilled}
             onChange={handleChange}
+            aria-invalid={error || undefined}
+            aria-describedby={error && errorMessage ? errorId : undefined}
             {...restProps}
           />
         </StyledInputWrapper>

--- a/packages/ui/src/TextField/TextField.tsx
+++ b/packages/ui/src/TextField/TextField.tsx
@@ -129,7 +129,7 @@ const StyledInputWrapper = styled.div<StyledInputWrapperProps>`
   width: ${({ width }) => (typeof width === 'number' ? `${width}px` : (width ?? '100%'))};
 `;
 
-const StyledIconWrapper = styled.div`
+const StyledIconWrapper = styled.label`
   position: absolute;
   left: 12px;
   top: 50%;

--- a/packages/ui/src/TextField/TextField.tsx
+++ b/packages/ui/src/TextField/TextField.tsx
@@ -183,7 +183,7 @@ const StyledInput = styled('input', { shouldForwardProp })<StyledInputProps>`
       box-shadow: inset 0 0 0 ${tokens.stroke.weight} ${tokens.colors.warning[200]};
       
       &:focus {
-        box-shadow: inset 0 0 0 2px ${tokens.colors.warning[200]};
+        box-shadow: inset 0 0 0 calc(${tokens.stroke.weight} * 2) ${tokens.colors.warning[200]};
       }
     `}
   
@@ -194,7 +194,7 @@ const StyledInput = styled('input', { shouldForwardProp })<StyledInputProps>`
       box-shadow: inset 0 0 0 ${tokens.stroke.weight} ${tokens.colors.primary[500]};
       
       &:focus {
-        box-shadow: inset 0 0 0 2px ${tokens.colors.primary[500]};
+        box-shadow: inset 0 0 0 calc(${tokens.stroke.weight} * 2) ${tokens.colors.primary[500]};
       }
     `}
   
@@ -205,7 +205,7 @@ const StyledInput = styled('input', { shouldForwardProp })<StyledInputProps>`
       box-shadow: inset 0 0 0 ${tokens.stroke.weight} ${tokens.colors.neutral[300]};
       
       &:focus {
-        box-shadow: inset 0 0 0 2px ${tokens.colors.primary[500]};
+        box-shadow: inset 0 0 0 calc(${tokens.stroke.weight} * 2) ${tokens.colors.primary[500]};
       }
     `}
 `;

--- a/packages/ui/src/TextField/TextField.tsx
+++ b/packages/ui/src/TextField/TextField.tsx
@@ -65,7 +65,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
       if (!error || !errorMessage) return null;
 
       return (
-        <StyledErrorMessage id={errorId} role='alert'>
+        <StyledErrorMessage id={errorId} aria-live='polite'>
           <Text variant='C' color={tokens.colors.warning[200]} textAlign='center'>
             {errorMessage}
           </Text>
@@ -164,7 +164,6 @@ const StyledInput = styled('input', { shouldForwardProp })<StyledInputProps>`
 
   &:focus {
     outline: none;
-    box-shadow: inset 0 0 0 2px;
   }
 
   &:disabled {
@@ -211,6 +210,6 @@ const StyledInput = styled('input', { shouldForwardProp })<StyledInputProps>`
     `}
 `;
 
-const StyledErrorMessage = styled.div`
+const StyledErrorMessage = styled.output`
   text-align: center;
 `;

--- a/packages/ui/src/TextField/TextField.tsx
+++ b/packages/ui/src/TextField/TextField.tsx
@@ -1,10 +1,10 @@
+import { Icon } from '@/Icon';
+import { Text } from '@/Text';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { tokens } from '@horizon/tokens';
 import type React from 'react';
 import { forwardRef, useCallback, useId, useMemo, useState } from 'react';
-import { Icon } from '../Icon';
-import { Text } from '../Text';
 
 interface TextFieldStyleProps {
   hasError: boolean;

--- a/packages/ui/src/TextField/TextField.tsx
+++ b/packages/ui/src/TextField/TextField.tsx
@@ -65,7 +65,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
       if (!error || !errorMessage) return null;
 
       return (
-        <StyledErrorMessage id={errorId} role='alert' aria-live='polite'>
+        <StyledErrorMessage id={errorId} role='alert'>
           <Text variant='C' color={tokens.colors.warning[200]} textAlign='center'>
             {errorMessage}
           </Text>
@@ -89,6 +89,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         <StyledInputWrapper width={width}>
           {renderIcon()}
           <StyledInput
+            {...restProps}
             id={resolvedId}
             ref={ref}
             hasError={error}
@@ -97,7 +98,6 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
             onChange={handleChange}
             aria-invalid={error || undefined}
             aria-describedby={error && errorMessage ? errorId : undefined}
-            {...restProps}
           />
         </StyledInputWrapper>
         {renderErrorMessage()}

--- a/packages/ui/src/TextField/TextField.tsx
+++ b/packages/ui/src/TextField/TextField.tsx
@@ -8,6 +8,7 @@ import { forwardRef, useCallback, useId, useState } from 'react';
 
 interface TextFieldProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size' | 'width'> {
+  id?: string;
   label?: string;
   icon?: string;
   error?: boolean;
@@ -22,6 +23,7 @@ const shouldForwardProp = (prop: string) => ['hasError', 'hasIcon', 'filled'].in
 export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
   (
     {
+      id,
       label,
       icon,
       error = false,
@@ -33,7 +35,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
     },
     ref
   ) => {
-    const resolvedId = (restProps.id as string | undefined) ?? useId();
+    const resolvedId = id ?? useId();
     const errorId = `${resolvedId}-error`;
     const [internalValue, setInternalValue] = useState(restProps.defaultValue ?? '');
 


### PR DESCRIPTION
## 🎫 관련 이슈

[//]: # 'close 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.'
[//]: # '예시: close #1'

close #62

<br>

## 📄 개요

[//]: # '작업 내용을 간단히 요약해서 적습니다.'
[//]: # '예시: 로그인 폼 컴포넌트를 구현했습니다.'

> TextField 리팩토링 했습니다.

<br>

## 🔨 작업 내용

[//]: # '작업 내용을 자세하게 적습니다.'
[//]: # '붙임표 "-" 을 사용해서 목록을 만듭니다.'
[//]: # '예시: - 로그인 폼 UI 컴포넌트 구현'

- 컴포넌트 퍼블리싱
- 리팩토링
- 스토리

<br>

## 🖼️ 스크린샷/화면 녹화

[//]: # 'UI 변경사항이 있다면 스크린샷이나 GIF를 첨부해주세요.'
[//]: # '모바일/데스크톱 화면 모두 확인이 필요한 경우 각각 첨부해주세요.'

<!-- 스크린샷 첨부 -->

<br>

## 🏁 확인 사항

[//]: # 'PR을 보내기 전 다음 사항을 확인해주세요.'
[//]: # '해당 사항을 모두 이행해야 머지할 수 있습니다.'
[//]: # '- [x] 를 사용해서 완료로 표시할 수 있습니다.'x

- [x] 테스트를 완료했나요?
- [x] 코드 컨벤션을 준수했나요? (Biome 검사 통과)
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?
- [x] 접근성(a11y)을 고려했나요?

<br>

## 🙋🏻 덧붙일 말

[//]: # '다음 사항이 있다면 적어주세요.'
[//]: # 'PR에 대한 추가 설명'
[//]: # '중점적으로 리뷰받고 싶은 부분'
[//]: # '기타 등등'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - TextField에 가변 너비(width) prop 추가 및 Compact/Standard/Full 예제 제공
  - 아이콘 표시, 에러 메시지, 라벨·포커스·채움 상태 개선 및 제어형/비제어형 입력 지원 강화
- 문서
  - Storybook 설명을 한국어로 갱신하고 controls를 너비 중심으로 재구성(Playground 기본값 defaultValue → width 전환)
  - 스토리명·공개 예제(WidthVariations)·그리드 기반 레이아웃 및 샘플 텍스트·코드 예시 업데이트
- 스타일
  - 디자인 토큰 기반 타이포그래피·테두리·간격 적용 및 상태별 시각 피드백 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->