### PR TITLE
Refactor: 버튼 컴포넌트 리팩토링

### DIFF
--- a/packages/ui/src/Button/Button.tsx
+++ b/packages/ui/src/Button/Button.tsx
@@ -1,29 +1,16 @@
-import ButtonIcon from '@/Button/ButtonIcon';
-import ButtonText from '@/Button/ButtonText';
+import type {
+  ButtonProps,
+  ButtonSize,
+  ButtonVariant,
+  IconPosition,
+  StyledButtonProps,
+} from '@/Button/types';
 import styled from '@emotion/styled';
 import { tokens } from '@horizon/tokens';
 import type React from 'react';
+import ButtonIcon from './ButtonIcon';
+import ButtonText from './ButtonText';
 import { getButtonStyle, getGapSize, getPadding } from './styles';
-
-export type ButtonSize = 'small' | 'medium' | 'large';
-export type ButtonVariant = 'contained' | 'outlined';
-export type IconPosition = 'none' | 'left' | 'right' | 'only';
-
-export interface ButtonProps<T extends React.ElementType = 'button'> {
-  as?: T;
-  size?: ButtonSize;
-  iconPosition?: IconPosition;
-  variant?: ButtonVariant;
-  rounded?: boolean;
-  children?: React.ReactNode;
-  iconName?: string;
-  iconFilled?: boolean;
-  disabled?: boolean;
-  type?: 'button' | 'submit' | 'reset';
-  'aria-label'?: string;
-  onClick?: (e: React.SyntheticEvent<HTMLElement>) => void;
-  onKeyDown?: React.KeyboardEventHandler<HTMLElement>;
-}
 
 const shouldForwardProp = (prop: string) =>
   ['size', 'variant', 'iconPosition', 'rounded'].indexOf(prop) === -1;
@@ -91,14 +78,6 @@ export const Button = <T extends React.ElementType = 'button'>({
     </StyledButton>
   );
 };
-
-interface StyledButtonProps {
-  size: ButtonSize;
-  variant: ButtonVariant;
-  iconPosition: IconPosition;
-  rounded: boolean;
-  disabled: boolean;
-}
 
 const StyledButton = styled('button', { shouldForwardProp })<StyledButtonProps>`
     display: inline-flex;

--- a/packages/ui/src/Button/Button.tsx
+++ b/packages/ui/src/Button/Button.tsx
@@ -1,10 +1,9 @@
 import ButtonIcon from '@/Button/ButtonIcon';
 import ButtonText from '@/Button/ButtonText';
-import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { tokens } from '@horizon/tokens';
 import type React from 'react';
-import { getGapSize, getPadding, getTextStyles } from './styles';
+import { getButtonStyle, getGapSize, getPadding } from './styles';
 
 export type ButtonSize = 'small' | 'medium' | 'large';
 export type ButtonVariant = 'contained' | 'outlined';
@@ -27,7 +26,7 @@ export interface ButtonProps<T extends React.ElementType = 'button'> {
 }
 
 const shouldForwardProp = (prop: string) =>
-  ['size', 'variant', 'iconPosition', 'rounded', '$isDisabledLink'].indexOf(prop) === -1;
+  ['size', 'variant', 'iconPosition', 'rounded'].indexOf(prop) === -1;
 
 export const Button = <T extends React.ElementType = 'button'>({
   as,
@@ -76,21 +75,11 @@ export const Button = <T extends React.ElementType = 'button'>({
     'aria-disabled': disabled,
     'aria-label': iconPosition === 'only' ? ariaLabel || iconName : undefined,
     ...(isNativeButton ? { type } : { role: 'button', tabIndex: disabled ? -1 : 0 }),
-    ...restProps,
-    ...(!isNativeButton && {
-      onKeyDown: (e: React.KeyboardEvent<HTMLElement>) => {
-        if (!disabled && (e.key === ' ' || e.key === 'Enter')) {
-          e.preventDefault();
-          onClick?.(e);
-        }
-        onKeyDown?.(e);
-      },
-    }),
   };
 
   if (disabled && isLink) {
     return (
-      <StyledButton as='span' {...finalProps} aria-disabled='true' $isDisabledLink>
+      <StyledButton as='span' {...finalProps}>
         {content}
       </StyledButton>
     );
@@ -109,80 +98,30 @@ interface StyledButtonProps {
   iconPosition: IconPosition;
   rounded: boolean;
   disabled: boolean;
-  $isDisabledLink?: boolean;
 }
 
 const StyledButton = styled('button', { shouldForwardProp })<StyledButtonProps>`
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-family: ${tokens.fontFamily.suit.join(', ')};
     user-select: none;
     transition: all 0.2s ease-in-out;
-    border: 0 solid transparent;
-    cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
     flex-shrink: 0;
     box-sizing: border-box;
     text-decoration: none;
-
+    
+    cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
     gap: ${({ size }) => getGapSize(size)};
     padding: ${({ size, iconPosition }) => getPadding(size, iconPosition)};
     border-radius: ${({ rounded }) => (rounded ? '20px' : '8px')};
-
-    ${({ size }) => getTextStyles(size)}
-
-    ${({ variant }) =>
-      variant === 'contained'
-        ? css`
-          background-color: ${tokens.colors.primary[500]};
-          color: white;
-
-          &:hover:not(:disabled) {
-            background-color: ${tokens.colors.primary[700]};
-          }
-
-          &:active:not(:disabled) {
-            background-color: ${tokens.colors.primary[900]};
-          }`
-        : css`
-          background-color: transparent;
-          color: ${tokens.colors.primary[500]};
-          box-shadow: inset 0 0 0 2px ${tokens.colors.primary[500]};
-
-          &:hover:not(:disabled) {
-            background-color: ${tokens.colors.primary[600]};
-            color: white;
-            box-shadow: inset 0 0 0 2px ${tokens.colors.primary[600]};
-          }
-
-          &:active:not(:disabled) {
-            background-color: ${tokens.colors.primary[900]};
-            color: white;
-            box-shadow: inset 0 0 0 2px ${tokens.colors.primary[900]};
-          }
-        `}
+    
+    ${({ variant, disabled }) => getButtonStyle(variant, disabled)}
 
     &:focus-visible {
-        outline: none;
-        box-shadow: ${({ variant }) =>
-          variant === 'outlined'
-            ? `inset 0 0 0 2px ${tokens.colors.primary[500]}, 0 0 0 2px ${tokens.colors.primary[200]}`
-            : `0 0 0 2px ${tokens.colors.primary[200]}`};
+      outline: none;
+      box-shadow: ${({ variant }) =>
+        variant === 'outlined'
+          ? `inset 0 0 0 2px ${tokens.colors.primary[500]}, 0 0 0 2px ${tokens.colors.primary[200]}`
+          : `0 0 0 2px ${tokens.colors.primary[200]}`};
     }
-
-    ${({ disabled, variant }) =>
-      disabled &&
-      css`
-                pointer-events: none;
-                background-color: ${variant === 'outlined' ? 'transparent' : tokens.colors.neutral[300]};
-                color: ${variant === 'outlined' ? tokens.colors.neutral[300] : 'white'};
-                box-shadow: ${variant === 'outlined' ? `inset 0 0 0 2px ${tokens.colors.neutral[300]}` : 'none'};
-            `}
-    
-    ${({ $isDisabledLink }) =>
-      $isDisabledLink &&
-      css`
-                pointer-events: none;
-                opacity: 0.5;
-            `}
 `;

--- a/packages/ui/src/Button/Button.tsx
+++ b/packages/ui/src/Button/Button.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { tokens } from '@horizon/tokens';
 import type React from 'react';
+import { getGapSize, getIconStyles, getPadding, getTextStyles } from './styles';
 
 export type ButtonSize = 'small' | 'medium' | 'large';
 export type ButtonVariant = 'contained' | 'outlined';
@@ -22,80 +23,6 @@ export interface ButtonProps<T extends React.ElementType = 'button'> {
   onClick?: (e: React.SyntheticEvent<HTMLElement>) => void;
   onKeyDown?: React.KeyboardEventHandler<HTMLElement>;
 }
-
-const createTextStyle = (
-  fontSize: keyof typeof tokens.fontSize,
-  lineHeight: keyof typeof tokens.lineHeight,
-) => css`
-  font-size: ${tokens.fontSize[fontSize]};
-  font-weight: ${tokens.fontWeight.semibold};
-  line-height: ${tokens.lineHeight[lineHeight]};
-  letter-spacing: ${tokens.letterSpacing[0]};
-`;
-
-const TEXT_STYLES = {
-  small: createTextStyle(13, 18),
-  medium: createTextStyle(14, 20),
-  large: createTextStyle(16, 24),
-} as const;
-
-const getTextStyles = (size: ButtonSize) => TEXT_STYLES[size];
-
-const ICON_CONFIGS = {
-  small: { fontSize: 16, fontWeight: 'regular' as const, grad: 0, opsz: 20 },
-  medium: { fontSize: 20, fontWeight: 'regular' as const, grad: 0, opsz: 24 },
-  large: { fontSize: 24, fontWeight: 'medium' as const, grad: 25, opsz: 40 },
-} as const;
-
-const getIconStyles = (size: ButtonSize) => {
-  const config = ICON_CONFIGS[size];
-  return {
-    fontSize: `${config.fontSize}px`,
-    fontWeight: tokens.fontWeight[config.fontWeight],
-    wght: tokens.fontWeight[config.fontWeight],
-    grad: tokens.icons.grade[config.grad as keyof typeof tokens.icons.grade],
-    opsz: tokens.icons.opticalSize[config.opsz as keyof typeof tokens.icons.opticalSize],
-  };
-};
-
-const GAP_SIZES = {
-  small: '6px',
-  medium: '8px',
-  large: '10px',
-} as const;
-
-const getGapSize = (size: ButtonSize) => GAP_SIZES[size];
-
-const HORIZONTAL_PADDINGS = {
-  small: '16px',
-  medium: '20px',
-  large: '24px',
-} as const;
-
-const VERTICAL_PADDING = '10px';
-
-const ICON_PADDINGS = {
-  small: '10px',
-  medium: '12px',
-  large: '14px',
-} as const;
-
-const getPadding = (size: ButtonSize, iconPosition: IconPosition) => {
-  const iconPadding = ICON_PADDINGS[size];
-  const horizontal = HORIZONTAL_PADDINGS[size];
-
-  if (iconPosition === 'only') {
-    return VERTICAL_PADDING;
-  }
-  if (iconPosition === 'left') {
-    return `${VERTICAL_PADDING} ${horizontal} ${VERTICAL_PADDING} ${iconPadding}`;
-  }
-  if (iconPosition === 'right') {
-    return `${VERTICAL_PADDING} ${iconPadding} ${VERTICAL_PADDING} ${horizontal}`;
-  }
-
-  return `${VERTICAL_PADDING} ${horizontal}`;
-};
 
 const shouldForwardProp = (prop: string) =>
   ['size', 'variant', 'iconPosition', 'rounded', '$isDisabledLink'].indexOf(prop) === -1;
@@ -272,16 +199,5 @@ const StyledIcon = styled.span<{ size: ButtonSize; filled: boolean }>`
     font-family: ${tokens.fontFamily.icon.join(', ')};
     user-select: none;
 
-    ${({ size, filled }) => {
-      const iconStyles = getIconStyles(size);
-      return css`
-            font-size: ${iconStyles.fontSize};
-            font-weight: ${iconStyles.fontWeight};
-            font-variation-settings:
-                    'FILL' ${filled ? tokens.icons.fill[1] : tokens.icons.fill[0]},
-                    'wght' ${iconStyles.wght},
-                    'GRAD' ${iconStyles.grad},
-                    'opsz' ${iconStyles.opsz};
-        `;
-    }}
+    ${({ size, filled }) => getIconStyles(size, filled ? 1 : 0)}
 `;

--- a/packages/ui/src/Button/Button.tsx
+++ b/packages/ui/src/Button/Button.tsx
@@ -1,8 +1,10 @@
+import ButtonIcon from '@/Button/ButtonIcon';
+import ButtonText from '@/Button/ButtonText';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { tokens } from '@horizon/tokens';
 import type React from 'react';
-import { getGapSize, getIconStyles, getPadding, getTextStyles } from './styles';
+import { getGapSize, getPadding, getTextStyles } from './styles';
 
 export type ButtonSize = 'small' | 'medium' | 'large';
 export type ButtonVariant = 'contained' | 'outlined';
@@ -47,26 +49,20 @@ export const Button = <T extends React.ElementType = 'button'>({
   const isNativeButton = element === 'button';
   const isLink = element === 'a' || 'href' in restProps;
 
-  const renderIcon = () => {
-    if (!iconName || iconPosition === 'none') return null;
-
-    return (
-      <StyledIcon size={size} filled={iconFilled} aria-hidden={iconPosition !== 'only'}>
-        {iconName}
-      </StyledIcon>
-    );
-  };
-
   const content = (() => {
     if (iconPosition === 'only') {
-      return renderIcon();
+      return <ButtonIcon size={size} iconName={iconName} filled={iconFilled} />;
     }
 
     return (
       <>
-        {iconPosition === 'left' && renderIcon()}
-        {children && <StyledText size={size}>{children}</StyledText>}
-        {iconPosition === 'right' && renderIcon()}
+        {iconPosition === 'left' && (
+          <ButtonIcon size={size} iconName={iconName} filled={iconFilled} aria-hidden={true} />
+        )}
+        {children && <ButtonText size={size}>{children}</ButtonText>}
+        {iconPosition === 'right' && (
+          <ButtonIcon size={size} iconName={iconName} filled={iconFilled} aria-hidden={true} />
+        )}
       </>
     );
   })();
@@ -189,15 +185,4 @@ const StyledButton = styled('button', { shouldForwardProp })<StyledButtonProps>`
                 pointer-events: none;
                 opacity: 0.5;
             `}
-`;
-
-const StyledText = styled.span<{ size: ButtonSize }>`
-    ${({ size }) => getTextStyles(size)}
-`;
-
-const StyledIcon = styled.span<{ size: ButtonSize; filled: boolean }>`
-    font-family: ${tokens.fontFamily.icon.join(', ')};
-    user-select: none;
-
-    ${({ size, filled }) => getIconStyles(size, filled ? 1 : 0)}
 `;

--- a/packages/ui/src/Button/ButtonIcon.tsx
+++ b/packages/ui/src/Button/ButtonIcon.tsx
@@ -1,15 +1,8 @@
-import type { ButtonSize } from '@/Button/Button';
 import { getIconStyles } from '@/Button/styles';
 import styled from '@emotion/styled';
 import { tokens } from '@horizon/tokens';
 import type React from 'react';
-
-interface ButtonIconProps {
-  size: ButtonSize;
-  iconName?: string;
-  filled: boolean;
-  'aria-hidden'?: boolean;
-}
+import type { ButtonIconProps, ButtonSize } from './types';
 
 const ButtonIcon = ({ size, iconName = 'check', filled, ...restProps }: ButtonIconProps) => {
   return (

--- a/packages/ui/src/Button/ButtonIcon.tsx
+++ b/packages/ui/src/Button/ButtonIcon.tsx
@@ -1,0 +1,29 @@
+import type { ButtonSize } from '@/Button/Button';
+import { getIconStyles } from '@/Button/styles';
+import styled from '@emotion/styled';
+import { tokens } from '@horizon/tokens';
+import type React from 'react';
+
+interface ButtonIconProps {
+  size: ButtonSize;
+  iconName?: string;
+  filled: boolean;
+  'aria-hidden'?: boolean;
+}
+
+const ButtonIcon = ({ size, iconName = 'check', filled, ...restProps }: ButtonIconProps) => {
+  return (
+    <StyledIcon size={size} filled={filled} {...restProps}>
+      {iconName}
+    </StyledIcon>
+  );
+};
+
+export default ButtonIcon;
+
+const StyledIcon = styled.span<{ size: ButtonSize; filled: boolean }>`
+    font-family: ${tokens.fontFamily.icon.join(', ')};
+    user-select: none;
+
+    ${({ size, filled }) => getIconStyles(size, filled ? 1 : 0)}
+`;

--- a/packages/ui/src/Button/ButtonText.tsx
+++ b/packages/ui/src/Button/ButtonText.tsx
@@ -1,12 +1,7 @@
-import type { ButtonSize } from '@/Button/Button';
-import { getTextStyles } from '@/Button/styles';
 import styled from '@emotion/styled';
 import type React from 'react';
-
-interface ButtonTextProps {
-  size: ButtonSize;
-  children: React.ReactNode;
-}
+import { getTextStyles } from './styles';
+import type { ButtonSize, ButtonTextProps } from './types';
 
 const ButtonText = ({ size, children }: ButtonTextProps) => {
   return <StyledText size={size}>{children}</StyledText>;

--- a/packages/ui/src/Button/ButtonText.tsx
+++ b/packages/ui/src/Button/ButtonText.tsx
@@ -1,0 +1,19 @@
+import type { ButtonSize } from '@/Button/Button';
+import { getTextStyles } from '@/Button/styles';
+import styled from '@emotion/styled';
+import type React from 'react';
+
+interface ButtonTextProps {
+  size: ButtonSize;
+  children: React.ReactNode;
+}
+
+const ButtonText = ({ size, children }: ButtonTextProps) => {
+  return <StyledText size={size}>{children}</StyledText>;
+};
+
+export default ButtonText;
+
+const StyledText = styled.span<{ size: ButtonSize }>`
+    ${({ size }) => getTextStyles(size)}
+`;

--- a/packages/ui/src/Button/styles.ts
+++ b/packages/ui/src/Button/styles.ts
@@ -106,7 +106,7 @@ const buttonStyles = {
       }
     `,
     disabled: css`
-      pointer-events: none;
+      cursor: not-allowed;
       background-color: ${tokens.colors.neutral[300]};
     `,
   },
@@ -127,10 +127,10 @@ const buttonStyles = {
       }
     `,
     disabled: css`
+      cursor: not-allowed;
       background-color: transparent;
       color: ${tokens.colors.neutral[300]};
       border: 1px solid ${tokens.colors.neutral[300]};
-      pointer-events: none;
     `,
   },
 };

--- a/packages/ui/src/Button/styles.ts
+++ b/packages/ui/src/Button/styles.ts
@@ -1,8 +1,6 @@
-import type { IconPosition } from '@/Button/Button';
 import { css } from '@emotion/react';
 import { tokens } from '@horizon/tokens';
-
-export type ButtonSize = 'small' | 'medium' | 'large';
+import type { ButtonSize, ButtonVariant, IconPosition } from './types';
 
 const makeTextStyle = (
   fontSize: keyof typeof tokens.fontSize,
@@ -135,6 +133,6 @@ const buttonStyles = {
   },
 };
 
-export const getButtonStyle = (variant: 'contained' | 'outlined', disabled: boolean) => {
+export const getButtonStyle = (variant: ButtonVariant, disabled: boolean) => {
   return buttonStyles[variant][disabled ? 'disabled' : 'default'];
 };

--- a/packages/ui/src/Button/styles.ts
+++ b/packages/ui/src/Button/styles.ts
@@ -1,0 +1,92 @@
+import type { IconPosition } from '@/Button/Button';
+import { css } from '@emotion/react';
+import { tokens } from '@horizon/tokens';
+
+export type ButtonSize = 'small' | 'medium' | 'large';
+
+const makeTextStyle = (
+  fontSize: keyof typeof tokens.fontSize,
+  fontWeight: keyof typeof tokens.fontWeight,
+  lineHeight: keyof typeof tokens.lineHeight,
+) => css`
+  font-size: ${tokens.fontSize[fontSize]};
+  font-weight: ${tokens.fontWeight[fontWeight]};
+  line-height: ${tokens.lineHeight[lineHeight]};
+  letter-spacing: 0;
+`;
+
+export const getTextStyles = (size: ButtonSize) => {
+  const styles: Record<ButtonSize, ReturnType<typeof css>> = {
+    small: makeTextStyle(13, 'semibold', 18),
+    medium: makeTextStyle(14, 'semibold', 20),
+    large: makeTextStyle(16, 'semibold', 24),
+  };
+
+  return styles[size];
+};
+
+const makeIconStyle = (
+  filled: keyof typeof tokens.icons.fill,
+  fontSizePx: string,
+  fontWeight: keyof typeof tokens.fontWeight,
+  grade: keyof typeof tokens.icons.grade,
+  opticalSize: keyof typeof tokens.icons.opticalSize,
+) =>
+  css({
+    fontSize: fontSizePx,
+    fontVariationSettings: `
+      'FILL' ${tokens.icons.fill[filled]},
+      'wght' ${tokens.fontWeight[fontWeight]}, 
+      'GRAD' ${tokens.icons.grade[grade]}, 
+      'opsz' ${tokens.icons.opticalSize[opticalSize]}
+    `,
+  });
+
+export const getIconStyles = (size: ButtonSize, filled: keyof typeof tokens.icons.fill) => {
+  const styles: Record<ButtonSize, ReturnType<typeof css>> = {
+    small: makeIconStyle(filled, '16px', 'regular', 0, 20),
+    medium: makeIconStyle(filled, '20px', 'regular', 0, 24),
+    large: makeIconStyle(filled, '24px', 'medium', 25, 40),
+  };
+
+  return styles[size];
+};
+
+const GAP_SIZES = {
+  small: '6px',
+  medium: '8px',
+  large: '10px',
+} as const;
+
+export const getGapSize = (size: ButtonSize) => GAP_SIZES[size];
+
+const HORIZONTAL_PADDINGS = {
+  small: '16px',
+  medium: '20px',
+  large: '24px',
+} as const;
+
+const VERTICAL_PADDING = '10px';
+
+const ICON_PADDINGS = {
+  small: '10px',
+  medium: '12px',
+  large: '14px',
+} as const;
+
+export const getPadding = (size: ButtonSize, iconPosition: IconPosition) => {
+  const iconPadding = ICON_PADDINGS[size];
+  const horizontal = HORIZONTAL_PADDINGS[size];
+
+  if (iconPosition === 'only') {
+    return VERTICAL_PADDING;
+  }
+  if (iconPosition === 'left') {
+    return `${VERTICAL_PADDING} ${horizontal} ${VERTICAL_PADDING} ${iconPadding}`;
+  }
+  if (iconPosition === 'right') {
+    return `${VERTICAL_PADDING} ${iconPadding} ${VERTICAL_PADDING} ${horizontal}`;
+  }
+
+  return `${VERTICAL_PADDING} ${horizontal}`;
+};

--- a/packages/ui/src/Button/styles.ts
+++ b/packages/ui/src/Button/styles.ts
@@ -90,3 +90,51 @@ export const getPadding = (size: ButtonSize, iconPosition: IconPosition) => {
 
   return `${VERTICAL_PADDING} ${horizontal}`;
 };
+
+const buttonStyles = {
+  contained: {
+    default: css`
+      background-color: ${tokens.colors.primary[500]};
+      color: white;
+        
+      &:hover {
+          background-color: ${tokens.colors.primary[700]};
+      }
+        
+      &:active {
+          background-color: ${tokens.colors.primary[900]};
+      }
+    `,
+    disabled: css`
+      pointer-events: none;
+      background-color: ${tokens.colors.neutral[300]};
+    `,
+  },
+  outlined: {
+    default: css`
+      background-color: transparent;
+      border: 1px solid ${tokens.colors.primary[500]};
+      color: ${tokens.colors.primary[500]};
+        
+      &:hover {
+        background-color: ${tokens.colors.primary[600]};
+        color: white;
+      }
+        
+      &:active {
+        background-color: ${tokens.colors.primary[900]};
+        color: white;
+      }
+    `,
+    disabled: css`
+      background-color: transparent;
+      color: ${tokens.colors.neutral[300]};
+      border: 1px solid ${tokens.colors.neutral[300]};
+      pointer-events: none;
+    `,
+  },
+};
+
+export const getButtonStyle = (variant: 'contained' | 'outlined', disabled: boolean) => {
+  return buttonStyles[variant][disabled ? 'disabled' : 'default'];
+};

--- a/packages/ui/src/Button/types.ts
+++ b/packages/ui/src/Button/types.ts
@@ -1,0 +1,41 @@
+import type React from 'react';
+
+export type ButtonSize = 'small' | 'medium' | 'large';
+export type ButtonVariant = 'contained' | 'outlined';
+export type IconPosition = 'none' | 'left' | 'right' | 'only';
+
+export interface ButtonProps<T extends React.ElementType = 'button'> {
+  as?: T;
+  size?: ButtonSize;
+  iconPosition?: IconPosition;
+  variant?: ButtonVariant;
+  rounded?: boolean;
+  children?: React.ReactNode;
+  iconName?: string;
+  iconFilled?: boolean;
+  disabled?: boolean;
+  type?: 'button' | 'submit' | 'reset';
+  'aria-label'?: string;
+  onClick?: (e: React.SyntheticEvent<HTMLElement>) => void;
+  onKeyDown?: React.KeyboardEventHandler<HTMLElement>;
+}
+
+export interface StyledButtonProps {
+  size: ButtonSize;
+  variant: ButtonVariant;
+  iconPosition: IconPosition;
+  rounded: boolean;
+  disabled: boolean;
+}
+
+export interface ButtonIconProps {
+  size: ButtonSize;
+  iconName?: string;
+  filled: boolean;
+  'aria-hidden'?: boolean;
+}
+
+export interface ButtonTextProps {
+  size: ButtonSize;
+  children: React.ReactNode;
+}


### PR DESCRIPTION
## 🎫 관련 이슈

[//]: # 'close 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.'
[//]: # '예시: close #1'

close #86

<br>

## 📄 개요

[//]: # '작업 내용을 간단히 요약해서 적습니다.'
[//]: # '예시: 로그인 폼 컴포넌트를 구현했습니다.'

>버튼 컴포넌트 리팩토링

<br>

## 🔨 작업 내용

[//]: # '작업 내용을 자세하게 적습니다.'
[//]: # '붙임표 "-" 을 사용해서 목록을 만듭니다.'
[//]: # '예시: - 로그인 폼 UI 컴포넌트 구현'

-버튼 컴포넌트 리팩토링

<br>

## 🖼️ 스크린샷/화면 녹화

[//]: # 'UI 변경사항이 있다면 스크린샷이나 GIF를 첨부해주세요.'
[//]: # '모바일/데스크톱 화면 모두 확인이 필요한 경우 각각 첨부해주세요.'

<!-- 스크린샷 첨부 -->

<br>

## 🏁 확인 사항

[//]: # 'PR을 보내기 전 다음 사항을 확인해주세요.'
[//]: # '해당 사항을 모두 이행해야 머지할 수 있습니다.'
[//]: # '- [x] 를 사용해서 완료로 표시할 수 있습니다.'

- [ ] 테스트를 완료했나요?
- [ ] 코드 컨벤션을 준수했나요? (Biome 검사 통과)
- [ ] 불필요한 로그, 주석, import 등을 삭제했나요?
- [ ] 접근성(a11y)을 고려했나요?

<br>

## 🙋🏻 덧붙일 말

[//]: # '다음 사항이 있다면 적어주세요.'
[//]: # 'PR에 대한 추가 설명'
[//]: # '중점적으로 리뷰받고 싶은 부분'
[//]: # '기타 등등'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 버튼 아이콘 전용/텍스트 전용 렌더링이 분리되어 아이콘만 버튼과 아이콘+텍스트 조합이 더 명확하게 표현됩니다.
- 접근성
  - 아이콘만 있는 버튼에 aria-label 사용을 권장합니다.
  - 좌/우 배치 아이콘을 스크린 리더에서 숨겨 노이즈를 줄였습니다.
- 리팩터링
  - 버튼 스타일 시스템을 일원화해 크기·변형·간격의 일관성을 높였습니다.
  - 비네이티브 버튼의 Space/Enter → 클릭 키 매핑을 제거했습니다.
- 작업
  - 버튼 관련 타입이 전용 모듈로 이전되었습니다. 타입 임포트 경로를 업데이트하세요.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->