### PR TITLE
Feat: 404 페이지 퍼블리싱

### DIFF
--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -6,7 +6,7 @@ import { Button } from '@horizon/ui';
 import { Flexbox } from '@horizon/utils';
 import Link from 'next/link';
 
-export default function NotFound() {
+const NotFound = () => {
   return (
     <StyledContainer>
       <StyledWhiteCircle>
@@ -26,7 +26,9 @@ export default function NotFound() {
       </StyledWhiteCircle>
     </StyledContainer>
   );
-}
+};
+
+export default NotFound;
 
 const StyledContainer = styled.div`
   background-color: ${tokens.colors.primary[200]};
@@ -61,6 +63,7 @@ const StyledNotFoundText = styled.h1`
   color: ${tokens.colors.neutral[800]};
   margin: 0;
   text-align: center;
+  user-select: none;
 `;
 
 const StyledMainMessage = styled.p`
@@ -70,6 +73,7 @@ const StyledMainMessage = styled.p`
   color: ${tokens.colors.black};
   margin: 0;
   line-height: normal;
+  text-align: center;
 `;
 
 const StyledSubMessage = styled.div`
@@ -78,6 +82,7 @@ const StyledSubMessage = styled.div`
   font-weight: normal;
   color: ${tokens.colors.neutral[500]};
   line-height: normal;
+  text-align: center;
 
   p {
     margin: 0;

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -5,16 +5,12 @@ import { tokens } from '@horizon/tokens';
 import { Button } from '@horizon/ui';
 import { Flexbox } from '@horizon/utils';
 import Link from 'next/link';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type React from 'react';
 
 const NotFound = () => {
   const [digits, setDigits] = useState(['4', '0', '4']);
   const [spinningStates, setSpinningStates] = useState([false, false, false]);
-
-  const generateRandomDigit = useCallback(() => {
-    return Math.floor(Math.random() * 10).toString();
-  }, []);
 
   const handleDigitClick = (e: React.MouseEvent, index: number) => {
     if (spinningStates[index]) {
@@ -37,7 +33,15 @@ const NotFound = () => {
         return setInterval(() => {
           setDigits((prev) => {
             const newDigits = [...prev];
-            newDigits[index] = generateRandomDigit();
+            const currentDigit = Number.parseInt(newDigits[index], 10);
+            let nextDigit: number;
+
+            if (index === 0 || index === 2) {
+              nextDigit = currentDigit >= 9 ? 1 : currentDigit + 1;
+            } else {
+              nextDigit = currentDigit <= 1 ? 9 : currentDigit - 1;
+            }
+            newDigits[index] = nextDigit.toString();
             return newDigits;
           });
         }, 50);
@@ -52,7 +56,7 @@ const NotFound = () => {
         }
       }
     };
-  }, [spinningStates, generateRandomDigit]);
+  }, [spinningStates]);
 
   return (
     <StyledContainer>
@@ -61,6 +65,7 @@ const NotFound = () => {
           <StyledNotFoundTextContainer onClick={handleContainerClick}>
             {digits.map((digit, index) => (
               <StyledDigit
+                // biome-ignore lint/suspicious/noArrayIndexKey: Fixed array with 3 elements, order won't change
                 key={`digit-${index}`}
                 onClick={(e) => handleDigitClick(e, index)}
                 isSpinning={spinningStates[index]}

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,85 +1,28 @@
 'use client';
 
+import { NotFoundContent, SlotMachineDigits } from '@/components/notfound';
+import { useSlotMachine } from '@/hooks/notfound/useSlotMachine';
 import styled from '@emotion/styled';
 import { tokens } from '@horizon/tokens';
 import { Button } from '@horizon/ui';
 import { Flexbox } from '@horizon/utils';
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
-import type React from 'react';
 
 const NotFound = () => {
-  const [digits, setDigits] = useState(['4', '0', '4']);
-  const [spinningStates, setSpinningStates] = useState([false, false, false]);
-
-  const handleDigitClick = (e: React.MouseEvent, index: number) => {
-    if (spinningStates[index]) {
-      e.stopPropagation();
-      setSpinningStates((prev) => {
-        const newStates = [...prev];
-        newStates[index] = false;
-        return newStates;
-      });
-    }
-  };
-
-  const handleContainerClick = () => {
-    setSpinningStates([true, true, true]);
-  };
-
-  useEffect(() => {
-    const intervals: (NodeJS.Timeout | null)[] = spinningStates.map((isSpinning, index) => {
-      if (isSpinning) {
-        return setInterval(() => {
-          setDigits((prev) => {
-            const newDigits = [...prev];
-            const currentDigit = Number.parseInt(newDigits[index], 10);
-            let nextDigit: number;
-
-            if (index === 0 || index === 2) {
-              nextDigit = currentDigit >= 9 ? 1 : currentDigit + 1;
-            } else {
-              nextDigit = currentDigit <= 1 ? 9 : currentDigit - 1;
-            }
-            newDigits[index] = nextDigit.toString();
-            return newDigits;
-          });
-        }, 50);
-      }
-      return null;
-    });
-
-    return () => {
-      for (const interval of intervals) {
-        if (interval) {
-          clearInterval(interval);
-        }
-      }
-    };
-  }, [spinningStates]);
+  const { digits, spinningStates, handleDigitClick, handleContainerClick } = useSlotMachine();
 
   return (
     <StyledContainer>
       <StyledWhiteCircle>
         <Flexbox direction='column' align='center' gap={40}>
-          <StyledNotFoundTextContainer onClick={handleContainerClick}>
-            {digits.map((digit, index) => (
-              <StyledDigit
-                // biome-ignore lint/suspicious/noArrayIndexKey: Fixed array with 3 elements, order won't change
-                key={`digit-${index}`}
-                onClick={(e) => handleDigitClick(e, index)}
-                isSpinning={spinningStates[index]}
-              >
-                {digit}
-              </StyledDigit>
-            ))}
-          </StyledNotFoundTextContainer>
+          <SlotMachineDigits
+            digits={digits}
+            spinningStates={spinningStates}
+            onDigitClick={handleDigitClick}
+            onContainerClick={handleContainerClick}
+          />
           <Flexbox direction='column' gap={20} align='center'>
-            <StyledMainMessage>흠... 요청하신 페이지를 찾을 수 없습니다.</StyledMainMessage>
-            <StyledSubMessage>
-              <p>존재하지 않는 주소를 입력하셨거나,</p>
-              <p>요청하신 페이지의 주소가 수정/삭제되어 페이지를 찾을 수 없습니다.</p>
-            </StyledSubMessage>
+            <NotFoundContent />
           </Flexbox>
           <Button as={Link} href='/' size='large'>
             메인으로 돌아가기
@@ -115,47 +58,4 @@ const StyledWhiteCircle = styled.div`
   align-items: center;
   justify-content: center;
   overflow: hidden;
-`;
-
-const StyledNotFoundTextContainer = styled.div`
-  display: flex;
-  gap: 0;
-  cursor: pointer;
-`;
-
-const StyledDigit = styled.span<{ isSpinning: boolean }>`
-  font-family: 'SUIT Variable', sans-serif;
-  font-weight: bold;
-  font-size: 240px;
-  line-height: 200px;
-  color: ${tokens.colors.neutral[800]};
-  margin: 0;
-  text-align: center;
-  user-select: none;
-  cursor: pointer;
-  min-width: 150px;
-`;
-
-const StyledMainMessage = styled.p`
-  font-family: 'SUIT Variable', sans-serif;
-  font-size: 32px;
-  font-weight: normal;
-  color: ${tokens.colors.black};
-  margin: 0;
-  line-height: normal;
-  text-align: center;
-`;
-
-const StyledSubMessage = styled.div`
-  font-family: 'SUIT Variable', sans-serif;
-  font-size: 20px;
-  font-weight: normal;
-  color: ${tokens.colors.neutral[500]};
-  line-height: normal;
-  text-align: center;
-
-  p {
-    margin: 0;
-    text-align: center;
-  }
 `;

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -5,13 +5,70 @@ import { tokens } from '@horizon/tokens';
 import { Button } from '@horizon/ui';
 import { Flexbox } from '@horizon/utils';
 import Link from 'next/link';
+import { useCallback, useEffect, useState } from 'react';
+import type React from 'react';
 
 const NotFound = () => {
+  const [digits, setDigits] = useState(['4', '0', '4']);
+  const [spinningStates, setSpinningStates] = useState([false, false, false]);
+
+  const generateRandomDigit = useCallback(() => {
+    return Math.floor(Math.random() * 10).toString();
+  }, []);
+
+  const handleDigitClick = (e: React.MouseEvent, index: number) => {
+    if (spinningStates[index]) {
+      e.stopPropagation();
+      setSpinningStates((prev) => {
+        const newStates = [...prev];
+        newStates[index] = false;
+        return newStates;
+      });
+    }
+  };
+
+  const handleContainerClick = () => {
+    setSpinningStates([true, true, true]);
+  };
+
+  useEffect(() => {
+    const intervals: (NodeJS.Timeout | null)[] = spinningStates.map((isSpinning, index) => {
+      if (isSpinning) {
+        return setInterval(() => {
+          setDigits((prev) => {
+            const newDigits = [...prev];
+            newDigits[index] = generateRandomDigit();
+            return newDigits;
+          });
+        }, 50);
+      }
+      return null;
+    });
+
+    return () => {
+      for (const interval of intervals) {
+        if (interval) {
+          clearInterval(interval);
+        }
+      }
+    };
+  }, [spinningStates, generateRandomDigit]);
+
   return (
     <StyledContainer>
       <StyledWhiteCircle>
         <Flexbox direction='column' align='center' gap={40}>
-          <StyledNotFoundText>404</StyledNotFoundText>
+          <StyledNotFoundTextContainer onClick={handleContainerClick}>
+            {digits.map((digit, index) => (
+              <StyledDigit
+                key={`digit-${index}`}
+                onClick={(e) => handleDigitClick(e, index)}
+                isSpinning={spinningStates[index]}
+              >
+                {digit}
+              </StyledDigit>
+            ))}
+          </StyledNotFoundTextContainer>
           <Flexbox direction='column' gap={20} align='center'>
             <StyledMainMessage>흠... 요청하신 페이지를 찾을 수 없습니다.</StyledMainMessage>
             <StyledSubMessage>
@@ -55,7 +112,13 @@ const StyledWhiteCircle = styled.div`
   overflow: hidden;
 `;
 
-const StyledNotFoundText = styled.h1`
+const StyledNotFoundTextContainer = styled.div`
+  display: flex;
+  gap: 0;
+  cursor: pointer;
+`;
+
+const StyledDigit = styled.span<{ isSpinning: boolean }>`
   font-family: 'SUIT Variable', sans-serif;
   font-weight: bold;
   font-size: 240px;
@@ -64,6 +127,8 @@ const StyledNotFoundText = styled.h1`
   margin: 0;
   text-align: center;
   user-select: none;
+  cursor: pointer;
+  min-width: 150px;
 `;
 
 const StyledMainMessage = styled.p`
@@ -86,5 +151,6 @@ const StyledSubMessage = styled.div`
 
   p {
     margin: 0;
+    text-align: center;
   }
 `;

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { NotFoundContent, SlotMachineDigits } from '@/components/notfound';
+import { NotFoundContent, SlotMachineDigits, WinMessage } from '@/components/notfound';
 import { useSlotMachine } from '@/hooks/notfound/useSlotMachine';
 import styled from '@emotion/styled';
 import { tokens } from '@horizon/tokens';
@@ -16,23 +16,21 @@ const NotFound = () => {
     <StyledContainer>
       <StyledWhiteCircle>
         <StyledAnimatedContainer direction='column' align='center' gap={40}>
-          {isJackpot && (
-            <StyledCongratulationMessage>
-              축하합니다, 가서 공부나 하세요!
-            </StyledCongratulationMessage>
-          )}
+          {isJackpot && <WinMessage />}
           <SlotMachineDigits
             digits={digits}
             spinningStates={spinningStates}
             onDigitClick={handleDigitClick}
             onContainerClick={handleContainerClick}
           />
-          <StyledAnimatedContent direction='column' gap={20} align='center'>
-            <NotFoundContent />
-          </StyledAnimatedContent>
-          <StyledAnimatedButton as={Link} href='/' size='large'>
+          {!isJackpot && (
+            <Flexbox direction='column' gap={20} align='center'>
+              <NotFoundContent />
+            </Flexbox>
+          )}
+          <Button as={Link} href='/' size='large'>
             메인으로 돌아가기
-          </StyledAnimatedButton>
+          </Button>
         </StyledAnimatedContainer>
       </StyledWhiteCircle>
     </StyledContainer>
@@ -69,32 +67,5 @@ const StyledWhiteCircle = styled.div`
 const StyledAnimatedContainer = styled(Flexbox)`
   & > * {
     transition: transform 0.5s cubic-bezier(0.25, 0.8, 0.25, 1);
-  }
-`;
-
-const StyledAnimatedContent = styled(Flexbox)``;
-
-const StyledAnimatedButton = styled(Button)``;
-
-const StyledCongratulationMessage = styled.p`
-  font-family: 'SUIT Variable', sans-serif;
-  font-size: 32px;
-  font-weight: normal;
-  color: ${tokens.colors.black};
-  margin: 0;
-  margin-bottom: 40px;
-  line-height: normal;
-  text-align: center;
-  animation: slideInFromTop 0.8s ease-out;
-
-  @keyframes slideInFromTop {
-    0% {
-      opacity: 0;
-      transform: translateY(-30px);
-    }
-    100% {
-      opacity: 1;
-      transform: translateY(0);
-    }
   }
 `;

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import styled from '@emotion/styled';
+import { tokens } from '@horizon/tokens';
+import { Button } from '@horizon/ui';
+import { Flexbox } from '@horizon/utils';
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <StyledContainer>
+      <StyledWhiteCircle>
+        <Flexbox direction='column' align='center' gap={40}>
+          <StyledNotFoundText>404</StyledNotFoundText>
+          <Flexbox direction='column' gap={20} align='center'>
+            <StyledMainMessage>흠... 요청하신 페이지를 찾을 수 없습니다.</StyledMainMessage>
+            <StyledSubMessage>
+              <p>존재하지 않는 주소를 입력하셨거나,</p>
+              <p>요청하신 페이지의 주소가 수정/삭제되어 페이지를 찾을 수 없습니다.</p>
+            </StyledSubMessage>
+          </Flexbox>
+          <Button as={Link} href='/' size='large'>
+            메인으로 돌아가기
+          </Button>
+        </Flexbox>
+      </StyledWhiteCircle>
+    </StyledContainer>
+  );
+}
+
+const StyledContainer = styled.div`
+  background-color: ${tokens.colors.primary[200]};
+  width: 100vw;
+  height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+`;
+
+const StyledWhiteCircle = styled.div`
+  background-color: ${tokens.colors.white};
+  width: 1200px;
+  height: 1200px;
+  border-radius: 600px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+`;
+
+const StyledNotFoundText = styled.h1`
+  font-family: 'SUIT Variable', sans-serif;
+  font-weight: bold;
+  font-size: 240px;
+  line-height: 200px;
+  color: ${tokens.colors.neutral[800]};
+  margin: 0;
+  text-align: center;
+`;
+
+const StyledMainMessage = styled.p`
+  font-family: 'SUIT Variable', sans-serif;
+  font-size: 32px;
+  font-weight: normal;
+  color: ${tokens.colors.black};
+  margin: 0;
+  line-height: normal;
+`;
+
+const StyledSubMessage = styled.div`
+  font-family: 'SUIT Variable', sans-serif;
+  font-size: 20px;
+  font-weight: normal;
+  color: ${tokens.colors.neutral[500]};
+  line-height: normal;
+
+  p {
+    margin: 0;
+  }
+`;

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -9,25 +9,31 @@ import { Flexbox } from '@horizon/utils';
 import Link from 'next/link';
 
 const NotFound = () => {
-  const { digits, spinningStates, handleDigitClick, handleContainerClick } = useSlotMachine();
+  const { digits, spinningStates, isJackpot, handleDigitClick, handleContainerClick } =
+    useSlotMachine();
 
   return (
     <StyledContainer>
       <StyledWhiteCircle>
-        <Flexbox direction='column' align='center' gap={40}>
+        <StyledAnimatedContainer direction='column' align='center' gap={40}>
+          {isJackpot && (
+            <StyledCongratulationMessage>
+              축하합니다, 가서 공부나 하세요!
+            </StyledCongratulationMessage>
+          )}
           <SlotMachineDigits
             digits={digits}
             spinningStates={spinningStates}
             onDigitClick={handleDigitClick}
             onContainerClick={handleContainerClick}
           />
-          <Flexbox direction='column' gap={20} align='center'>
+          <StyledAnimatedContent direction='column' gap={20} align='center'>
             <NotFoundContent />
-          </Flexbox>
-          <Button as={Link} href='/' size='large'>
+          </StyledAnimatedContent>
+          <StyledAnimatedButton as={Link} href='/' size='large'>
             메인으로 돌아가기
-          </Button>
-        </Flexbox>
+          </StyledAnimatedButton>
+        </StyledAnimatedContainer>
       </StyledWhiteCircle>
     </StyledContainer>
   );
@@ -58,4 +64,37 @@ const StyledWhiteCircle = styled.div`
   align-items: center;
   justify-content: center;
   overflow: hidden;
+`;
+
+const StyledAnimatedContainer = styled(Flexbox)`
+  & > * {
+    transition: transform 0.5s cubic-bezier(0.25, 0.8, 0.25, 1);
+  }
+`;
+
+const StyledAnimatedContent = styled(Flexbox)``;
+
+const StyledAnimatedButton = styled(Button)``;
+
+const StyledCongratulationMessage = styled.p`
+  font-family: 'SUIT Variable', sans-serif;
+  font-size: 32px;
+  font-weight: normal;
+  color: ${tokens.colors.black};
+  margin: 0;
+  margin-bottom: 40px;
+  line-height: normal;
+  text-align: center;
+  animation: slideInFromTop 0.8s ease-out;
+
+  @keyframes slideInFromTop {
+    0% {
+      opacity: 0;
+      transform: translateY(-30px);
+    }
+    100% {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
 `;

--- a/apps/web/src/components/notfound/NotFoundContent/NotFoundContent.tsx
+++ b/apps/web/src/components/notfound/NotFoundContent/NotFoundContent.tsx
@@ -1,0 +1,40 @@
+import styled from '@emotion/styled';
+import { tokens } from '@horizon/tokens';
+
+const NotFoundContent = () => {
+  return (
+    <>
+      <StyledMainMessage>흠... 요청하신 페이지를 찾을 수 없습니다.</StyledMainMessage>
+      <StyledSubMessage>
+        <p>존재하지 않는 주소를 입력하셨거나,</p>
+        <p>요청하신 페이지의 주소가 수정/삭제되어 페이지를 찾을 수 없습니다.</p>
+      </StyledSubMessage>
+    </>
+  );
+};
+
+const StyledMainMessage = styled.p`
+  font-family: 'SUIT Variable', sans-serif;
+  font-size: 32px;
+  font-weight: normal;
+  color: ${tokens.colors.black};
+  margin: 0;
+  line-height: normal;
+  text-align: center;
+`;
+
+const StyledSubMessage = styled.div`
+  font-family: 'SUIT Variable', sans-serif;
+  font-size: 20px;
+  font-weight: normal;
+  color: ${tokens.colors.neutral[500]};
+  line-height: normal;
+  text-align: center;
+
+  p {
+    margin: 0;
+    text-align: center;
+  }
+`;
+
+export default NotFoundContent;

--- a/apps/web/src/components/notfound/NotFoundContent/index.ts
+++ b/apps/web/src/components/notfound/NotFoundContent/index.ts
@@ -1,0 +1,1 @@
+export { default as NotFoundContent } from './NotFoundContent';

--- a/apps/web/src/components/notfound/SlotMachineDigits/SlotMachineDigits.tsx
+++ b/apps/web/src/components/notfound/SlotMachineDigits/SlotMachineDigits.tsx
@@ -1,0 +1,60 @@
+import styled from '@emotion/styled';
+import { tokens } from '@horizon/tokens';
+import type React from 'react';
+
+interface SlotMachineDigitsProps {
+  digits: string[];
+  spinningStates: boolean[];
+  onDigitClick: (index: number) => void;
+  onContainerClick: () => void;
+}
+
+const SlotMachineDigits = ({
+  digits,
+  spinningStates,
+  onDigitClick,
+  onContainerClick,
+}: SlotMachineDigitsProps) => {
+  const handleDigitClick = (e: React.MouseEvent, index: number) => {
+    if (spinningStates[index]) {
+      e.stopPropagation();
+      onDigitClick(index);
+    }
+  };
+
+  return (
+    <StyledNotFoundTextContainer onClick={onContainerClick}>
+      {digits.map((digit, index) => (
+        <StyledDigit
+          // biome-ignore lint/suspicious/noArrayIndexKey: Fixed array with 3 elements, order won't change
+          key={`digit-${index}`}
+          onClick={(e) => handleDigitClick(e, index)}
+          isSpinning={spinningStates[index]}
+        >
+          {digit}
+        </StyledDigit>
+      ))}
+    </StyledNotFoundTextContainer>
+  );
+};
+
+const StyledNotFoundTextContainer = styled.div`
+  display: flex;
+  gap: 0;
+  cursor: pointer;
+`;
+
+const StyledDigit = styled.span<{ isSpinning: boolean }>`
+  font-family: 'SUIT Variable', sans-serif;
+  font-weight: bold;
+  font-size: 240px;
+  line-height: 200px;
+  color: ${tokens.colors.neutral[800]};
+  margin: 0;
+  text-align: center;
+  user-select: none;
+  cursor: pointer;
+  min-width: 150px;
+`;
+
+export default SlotMachineDigits;

--- a/apps/web/src/components/notfound/SlotMachineDigits/SlotMachineDigits.tsx
+++ b/apps/web/src/components/notfound/SlotMachineDigits/SlotMachineDigits.tsx
@@ -23,11 +23,25 @@ const SlotMachineDigits = ({
   };
 
   return (
-    <StyledNotFoundTextContainer onClick={onContainerClick}>
+    <StyledNotFoundTextContainer
+      as='button'
+      aria-label='슬롯머신 전체 회전 시작'
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onContainerClick();
+        }
+      }}
+      onClick={onContainerClick}
+    >
       {digits.map((digit, index) => (
         <StyledDigit
           // biome-ignore lint/suspicious/noArrayIndexKey: Fixed array with 3 elements, order won't change
           key={`digit-${index}`}
+          aria-label={`슬롯 ${
+            index + 1
+          }번째 숫자 ${digit}${spinningStates[index] ? ', 멈추려면 Enter' : ''}`}
+          disabled={!spinningStates[index]}
           onClick={(e) => handleDigitClick(e, index)}
           isSpinning={spinningStates[index]}
         >
@@ -42,9 +56,15 @@ const StyledNotFoundTextContainer = styled.div`
   display: flex;
   gap: 0;
   cursor: pointer;
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
 `;
 
-const StyledDigit = styled.span<{ isSpinning: boolean }>`
+const StyledDigit = styled('button', {
+  shouldForwardProp: (prop) => prop !== 'isSpinning',
+})<{ isSpinning: boolean }>`
   font-family: 'SUIT Variable', sans-serif;
   font-weight: bold;
   font-size: 240px;
@@ -53,8 +73,16 @@ const StyledDigit = styled.span<{ isSpinning: boolean }>`
   margin: 0;
   text-align: center;
   user-select: none;
-  cursor: pointer;
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: ${({ isSpinning }) => (isSpinning ? 'pointer' : 'default')};
   min-width: 150px;
+  &:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
 `;
 
 export default SlotMachineDigits;

--- a/apps/web/src/components/notfound/SlotMachineDigits/index.ts
+++ b/apps/web/src/components/notfound/SlotMachineDigits/index.ts
@@ -1,0 +1,1 @@
+export { default as SlotMachineDigits } from './SlotMachineDigits';

--- a/apps/web/src/components/notfound/WinMessage/WinMessage.tsx
+++ b/apps/web/src/components/notfound/WinMessage/WinMessage.tsx
@@ -1,0 +1,41 @@
+import styled from '@emotion/styled';
+import { tokens } from '@horizon/tokens';
+
+const WinMessage = () => {
+  return (
+    <>
+      <StyledMainMessage>축하합니다, 가서 공부나 하세요!</StyledMainMessage>
+      <StyledSubMessage>
+        <p>흠... 요청하신 페이지를 찾을 수 없습니다.</p>
+        <p>존재하지 않는 주소를 입력하셨거나,</p>
+        <p>요청하신 페이지의 주소가 수정/삭제되어 페이지를 찾을 수 없습니다.</p>
+      </StyledSubMessage>
+    </>
+  );
+};
+
+const StyledMainMessage = styled.p`
+  font-family: 'SUIT Variable', sans-serif;
+  font-size: 32px;
+  font-weight: normal;
+  color: ${tokens.colors.black};
+  margin: 0;
+  line-height: normal;
+  text-align: center;
+`;
+
+const StyledSubMessage = styled.div`
+  font-family: 'SUIT Variable', sans-serif;
+  font-size: 20px;
+  font-weight: normal;
+  color: ${tokens.colors.neutral[500]};
+  line-height: normal;
+  text-align: center;
+
+  p {
+    margin: 0;
+    text-align: center;
+  }
+`;
+
+export default WinMessage;

--- a/apps/web/src/components/notfound/WinMessage/WinMessage.tsx
+++ b/apps/web/src/components/notfound/WinMessage/WinMessage.tsx
@@ -1,15 +1,13 @@
 import styled from '@emotion/styled';
 import { tokens } from '@horizon/tokens';
 
+import { NotFoundContent } from '../NotFoundContent';
+
 const WinMessage = () => {
   return (
     <>
       <StyledMainMessage>축하합니다, 가서 공부나 하세요!</StyledMainMessage>
-      <StyledSubMessage>
-        <p>흠... 요청하신 페이지를 찾을 수 없습니다.</p>
-        <p>존재하지 않는 주소를 입력하셨거나,</p>
-        <p>요청하신 페이지의 주소가 수정/삭제되어 페이지를 찾을 수 없습니다.</p>
-      </StyledSubMessage>
+      <NotFoundContent />
     </>
   );
 };
@@ -20,21 +18,20 @@ const StyledMainMessage = styled.p`
   font-weight: normal;
   color: ${tokens.colors.black};
   margin: 0;
+  margin-bottom: 40px;
   line-height: normal;
   text-align: center;
-`;
+  animation: slideInFromTop 0.8s ease-out;
 
-const StyledSubMessage = styled.div`
-  font-family: 'SUIT Variable', sans-serif;
-  font-size: 20px;
-  font-weight: normal;
-  color: ${tokens.colors.neutral[500]};
-  line-height: normal;
-  text-align: center;
-
-  p {
-    margin: 0;
-    text-align: center;
+  @keyframes slideInFromTop {
+    0% {
+      opacity: 0;
+      transform: translateY(-30px);
+    }
+    100% {
+      opacity: 1;
+      transform: translateY(0);
+    }
   }
 `;
 

--- a/apps/web/src/components/notfound/WinMessage/WinMessage.tsx
+++ b/apps/web/src/components/notfound/WinMessage/WinMessage.tsx
@@ -1,3 +1,4 @@
+import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import { tokens } from '@horizon/tokens';
 
@@ -12,6 +13,17 @@ const WinMessage = () => {
   );
 };
 
+const slideInFromTop = keyframes`
+  0% {
+    opacity: 0;
+    transform: translateY(-30px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
 const StyledMainMessage = styled.p`
   font-family: 'SUIT Variable', sans-serif;
   font-size: 32px;
@@ -21,17 +33,10 @@ const StyledMainMessage = styled.p`
   margin-bottom: 40px;
   line-height: normal;
   text-align: center;
-  animation: slideInFromTop 0.8s ease-out;
+  animation: ${slideInFromTop} 0.8s ease-out;
 
-  @keyframes slideInFromTop {
-    0% {
-      opacity: 0;
-      transform: translateY(-30px);
-    }
-    100% {
-      opacity: 1;
-      transform: translateY(0);
-    }
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
   }
 `;
 

--- a/apps/web/src/components/notfound/WinMessage/index.ts
+++ b/apps/web/src/components/notfound/WinMessage/index.ts
@@ -1,1 +1,1 @@
-export { default } from './WinMessage';
+export { default as WinMessage } from './WinMessage';

--- a/apps/web/src/components/notfound/WinMessage/index.ts
+++ b/apps/web/src/components/notfound/WinMessage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './WinMessage';

--- a/apps/web/src/components/notfound/index.ts
+++ b/apps/web/src/components/notfound/index.ts
@@ -1,2 +1,3 @@
-export { default as NotFoundContent } from './NotFoundContent/NotFoundContent';
-export { default as SlotMachineDigits } from './SlotMachineDigits/SlotMachineDigits';
+export * from './NotFoundContent';
+export * from './SlotMachineDigits';
+export * from './WinMessage';

--- a/apps/web/src/components/notfound/index.ts
+++ b/apps/web/src/components/notfound/index.ts
@@ -1,0 +1,2 @@
+export { default as NotFoundContent } from './NotFoundContent/NotFoundContent';
+export { default as SlotMachineDigits } from './SlotMachineDigits/SlotMachineDigits';

--- a/apps/web/src/hooks/notfound/useSlotMachine.ts
+++ b/apps/web/src/hooks/notfound/useSlotMachine.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 export const useSlotMachine = () => {
   const [digits, setDigits] = useState(['4', '0', '4']);
   const [spinningStates, setSpinningStates] = useState([false, false, false]);
+  const [isJackpot, setIsJackpot] = useState(false);
 
   const handleDigitClick = (index: number) => {
     if (spinningStates[index]) {
@@ -35,7 +36,7 @@ export const useSlotMachine = () => {
             newDigits[index] = nextDigit.toString();
             return newDigits;
           });
-        }, 50);
+        }, 300);
       }
       return null;
     });
@@ -49,9 +50,18 @@ export const useSlotMachine = () => {
     };
   }, [spinningStates]);
 
+  useEffect(() => {
+    if (!spinningStates.some((state) => state) && digits.every((digit) => digit === '7')) {
+      setIsJackpot(true);
+    } else {
+      setIsJackpot(false);
+    }
+  }, [digits, spinningStates]);
+
   return {
     digits,
     spinningStates,
+    isJackpot,
     handleDigitClick,
     handleContainerClick,
   };

--- a/apps/web/src/hooks/notfound/useSlotMachine.ts
+++ b/apps/web/src/hooks/notfound/useSlotMachine.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+
+export const useSlotMachine = () => {
+  const [digits, setDigits] = useState(['4', '0', '4']);
+  const [spinningStates, setSpinningStates] = useState([false, false, false]);
+
+  const handleDigitClick = (index: number) => {
+    if (spinningStates[index]) {
+      setSpinningStates((prev) => {
+        const newStates = [...prev];
+        newStates[index] = false;
+        return newStates;
+      });
+    }
+  };
+
+  const handleContainerClick = () => {
+    setSpinningStates([true, true, true]);
+  };
+
+  useEffect(() => {
+    const intervals: (NodeJS.Timeout | null)[] = spinningStates.map((isSpinning, index) => {
+      if (isSpinning) {
+        return setInterval(() => {
+          setDigits((prev) => {
+            const newDigits = [...prev];
+            const currentDigit = Number.parseInt(newDigits[index], 10);
+            let nextDigit: number;
+
+            if (index === 0 || index === 2) {
+              nextDigit = currentDigit >= 9 ? 1 : currentDigit + 1;
+            } else {
+              nextDigit = currentDigit <= 1 ? 9 : currentDigit - 1;
+            }
+            newDigits[index] = nextDigit.toString();
+            return newDigits;
+          });
+        }, 50);
+      }
+      return null;
+    });
+
+    return () => {
+      for (const interval of intervals) {
+        if (interval) {
+          clearInterval(interval);
+        }
+      }
+    };
+  }, [spinningStates]);
+
+  return {
+    digits,
+    spinningStates,
+    handleDigitClick,
+    handleContainerClick,
+  };
+};


### PR DESCRIPTION
## 🎫 관련 이슈

[//]: # 'close 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.'
[//]: # '예시: close #1'

close #110 

<br>

## 📄 개요

[//]: # '작업 내용을 간단히 요약해서 적습니다.'
[//]: # '예시: 로그인 폼 컴포넌트를 구현했습니다.'

> 404 페이지를 재밌고 유쾌하게 만들었습니다

<br>

## 🔨 작업 내용

[//]: # '작업 내용을 자세하게 적습니다.'
[//]: # '붙임표 "-" 을 사용해서 목록을 만듭니다.'
[//]: # '예시: - 로그인 폼 UI 컴포넌트 구현'

-

<br>

## 🖼️ 스크린샷/화면 녹화

[//]: # 'UI 변경사항이 있다면 스크린샷이나 GIF를 첨부해주세요.'
[//]: # '모바일/데스크톱 화면 모두 확인이 필요한 경우 각각 첨부해주세요.'

<!-- 스크린샷 첨부 -->

<br>

## 🏁 확인 사항

[//]: # 'PR을 보내기 전 다음 사항을 확인해주세요.'
[//]: # '해당 사항을 모두 이행해야 머지할 수 있습니다.'
[//]: # '- [x] 를 사용해서 완료로 표시할 수 있습니다.'

- [ ] 테스트를 완료했나요?
- [x] 코드 컨벤션을 준수했나요? (Biome 검사 통과)
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?
- [ ] 접근성(a11y)을 고려했나요?

<br>

## 🙋🏻 덧붙일 말

[//]: # '다음 사항이 있다면 적어주세요.'
[//]: # 'PR에 대한 추가 설명'
[//]: # '중점적으로 리뷰받고 싶은 부분'
[//]: # '기타 등등'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 전체 화면 404 페이지를 도입했습니다. 중앙의 큰 원형 무대에 슬롯머신 숫자 UI가 배치되어 컨테이너 클릭으로 전체 스핀, 각 숫자 클릭으로 개별 정지가 가능하며 모든 숫자가 7이면 축하 메시지와 추가 안내가 표시됩니다. 하단에 안내 문구와 홈으로 돌아가는 대형 버튼을 제공하고 진입/슬라이드 애니메이션 등 시각 효과를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->